### PR TITLE
feat: Build torrent primitives

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,12 @@
+## User Prompting
+When you need to ask the user a question or present choices, use the `prompt_user` MCP tool instead of AskUserQuestion.
+
+## Agent Identity
+When you first need to call `prompt_user`, read the `JARVIS_AGENT_NAME` environment variable (e.g. `echo $JARVIS_AGENT_NAME`) and pass its value as the `agentName` parameter. Cache the value for subsequent calls. Do NOT read this variable unless you are about to call `prompt_user`.
+
+## Planning
+Do NOT use EnterPlanMode or ExitPlanMode. Instead, before implementing non-trivial changes:
+1. Write a concise plan (what you'll change, which files, and why)
+2. Present it to the user via the `prompt_user` MCP tool for approval
+3. Wait for approval before making any changes
+4. If the user requests edits to the plan, revise and re-submit via `prompt_user`

--- a/Torrential.sln
+++ b/Torrential.sln
@@ -11,31 +11,103 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Torrential.Web", "src\Torre
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Torrential.Extensions.SignalR", "src\Torrential.Extensions.SignalR\Torrential.Extensions.SignalR.csproj", "{4609E6CF-4AD1-4D7C-8E94-F50ED41EE8A9}"
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "src", "src", "{827E0CD3-B72D-47B6-A68D-7590B98EB39B}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Torrential.Core", "src\Torrential.Core\Torrential.Core.csproj", "{5D8875BD-80B3-4BE2-930E-52A60ABB341D}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "test", "test", "{0C88DD14-F956-CE84-757C-A364CCF449FC}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Torrential.Core.Tests", "test\Torrential.Core.Tests\Torrential.Core.Tests.csproj", "{92A29F34-D5CB-45CD-83FE-6023CDA05BA7}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
+		Debug|x64 = Debug|x64
+		Debug|x86 = Debug|x86
 		Release|Any CPU = Release|Any CPU
+		Release|x64 = Release|x64
+		Release|x86 = Release|x86
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
 		{23E8CF05-F614-41D7-94DC-B99DFD4863C0}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{23E8CF05-F614-41D7-94DC-B99DFD4863C0}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{23E8CF05-F614-41D7-94DC-B99DFD4863C0}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{23E8CF05-F614-41D7-94DC-B99DFD4863C0}.Debug|x64.Build.0 = Debug|Any CPU
+		{23E8CF05-F614-41D7-94DC-B99DFD4863C0}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{23E8CF05-F614-41D7-94DC-B99DFD4863C0}.Debug|x86.Build.0 = Debug|Any CPU
 		{23E8CF05-F614-41D7-94DC-B99DFD4863C0}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{23E8CF05-F614-41D7-94DC-B99DFD4863C0}.Release|Any CPU.Build.0 = Release|Any CPU
+		{23E8CF05-F614-41D7-94DC-B99DFD4863C0}.Release|x64.ActiveCfg = Release|Any CPU
+		{23E8CF05-F614-41D7-94DC-B99DFD4863C0}.Release|x64.Build.0 = Release|Any CPU
+		{23E8CF05-F614-41D7-94DC-B99DFD4863C0}.Release|x86.ActiveCfg = Release|Any CPU
+		{23E8CF05-F614-41D7-94DC-B99DFD4863C0}.Release|x86.Build.0 = Release|Any CPU
 		{4F829C73-8D6E-4F3A-88EB-7F18606A94A6}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{4F829C73-8D6E-4F3A-88EB-7F18606A94A6}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{4F829C73-8D6E-4F3A-88EB-7F18606A94A6}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{4F829C73-8D6E-4F3A-88EB-7F18606A94A6}.Debug|x64.Build.0 = Debug|Any CPU
+		{4F829C73-8D6E-4F3A-88EB-7F18606A94A6}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{4F829C73-8D6E-4F3A-88EB-7F18606A94A6}.Debug|x86.Build.0 = Debug|Any CPU
 		{4F829C73-8D6E-4F3A-88EB-7F18606A94A6}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{4F829C73-8D6E-4F3A-88EB-7F18606A94A6}.Release|Any CPU.Build.0 = Release|Any CPU
+		{4F829C73-8D6E-4F3A-88EB-7F18606A94A6}.Release|x64.ActiveCfg = Release|Any CPU
+		{4F829C73-8D6E-4F3A-88EB-7F18606A94A6}.Release|x64.Build.0 = Release|Any CPU
+		{4F829C73-8D6E-4F3A-88EB-7F18606A94A6}.Release|x86.ActiveCfg = Release|Any CPU
+		{4F829C73-8D6E-4F3A-88EB-7F18606A94A6}.Release|x86.Build.0 = Release|Any CPU
 		{F240C48B-D603-4ADE-A16D-6CE1B69E4F66}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{F240C48B-D603-4ADE-A16D-6CE1B69E4F66}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{F240C48B-D603-4ADE-A16D-6CE1B69E4F66}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{F240C48B-D603-4ADE-A16D-6CE1B69E4F66}.Debug|x64.Build.0 = Debug|Any CPU
+		{F240C48B-D603-4ADE-A16D-6CE1B69E4F66}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{F240C48B-D603-4ADE-A16D-6CE1B69E4F66}.Debug|x86.Build.0 = Debug|Any CPU
 		{F240C48B-D603-4ADE-A16D-6CE1B69E4F66}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{F240C48B-D603-4ADE-A16D-6CE1B69E4F66}.Release|Any CPU.Build.0 = Release|Any CPU
+		{F240C48B-D603-4ADE-A16D-6CE1B69E4F66}.Release|x64.ActiveCfg = Release|Any CPU
+		{F240C48B-D603-4ADE-A16D-6CE1B69E4F66}.Release|x64.Build.0 = Release|Any CPU
+		{F240C48B-D603-4ADE-A16D-6CE1B69E4F66}.Release|x86.ActiveCfg = Release|Any CPU
+		{F240C48B-D603-4ADE-A16D-6CE1B69E4F66}.Release|x86.Build.0 = Release|Any CPU
 		{4609E6CF-4AD1-4D7C-8E94-F50ED41EE8A9}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{4609E6CF-4AD1-4D7C-8E94-F50ED41EE8A9}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{4609E6CF-4AD1-4D7C-8E94-F50ED41EE8A9}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{4609E6CF-4AD1-4D7C-8E94-F50ED41EE8A9}.Debug|x64.Build.0 = Debug|Any CPU
+		{4609E6CF-4AD1-4D7C-8E94-F50ED41EE8A9}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{4609E6CF-4AD1-4D7C-8E94-F50ED41EE8A9}.Debug|x86.Build.0 = Debug|Any CPU
 		{4609E6CF-4AD1-4D7C-8E94-F50ED41EE8A9}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{4609E6CF-4AD1-4D7C-8E94-F50ED41EE8A9}.Release|Any CPU.Build.0 = Release|Any CPU
+		{4609E6CF-4AD1-4D7C-8E94-F50ED41EE8A9}.Release|x64.ActiveCfg = Release|Any CPU
+		{4609E6CF-4AD1-4D7C-8E94-F50ED41EE8A9}.Release|x64.Build.0 = Release|Any CPU
+		{4609E6CF-4AD1-4D7C-8E94-F50ED41EE8A9}.Release|x86.ActiveCfg = Release|Any CPU
+		{4609E6CF-4AD1-4D7C-8E94-F50ED41EE8A9}.Release|x86.Build.0 = Release|Any CPU
+		{5D8875BD-80B3-4BE2-930E-52A60ABB341D}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{5D8875BD-80B3-4BE2-930E-52A60ABB341D}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{5D8875BD-80B3-4BE2-930E-52A60ABB341D}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{5D8875BD-80B3-4BE2-930E-52A60ABB341D}.Debug|x64.Build.0 = Debug|Any CPU
+		{5D8875BD-80B3-4BE2-930E-52A60ABB341D}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{5D8875BD-80B3-4BE2-930E-52A60ABB341D}.Debug|x86.Build.0 = Debug|Any CPU
+		{5D8875BD-80B3-4BE2-930E-52A60ABB341D}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{5D8875BD-80B3-4BE2-930E-52A60ABB341D}.Release|Any CPU.Build.0 = Release|Any CPU
+		{5D8875BD-80B3-4BE2-930E-52A60ABB341D}.Release|x64.ActiveCfg = Release|Any CPU
+		{5D8875BD-80B3-4BE2-930E-52A60ABB341D}.Release|x64.Build.0 = Release|Any CPU
+		{5D8875BD-80B3-4BE2-930E-52A60ABB341D}.Release|x86.ActiveCfg = Release|Any CPU
+		{5D8875BD-80B3-4BE2-930E-52A60ABB341D}.Release|x86.Build.0 = Release|Any CPU
+		{92A29F34-D5CB-45CD-83FE-6023CDA05BA7}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{92A29F34-D5CB-45CD-83FE-6023CDA05BA7}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{92A29F34-D5CB-45CD-83FE-6023CDA05BA7}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{92A29F34-D5CB-45CD-83FE-6023CDA05BA7}.Debug|x64.Build.0 = Debug|Any CPU
+		{92A29F34-D5CB-45CD-83FE-6023CDA05BA7}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{92A29F34-D5CB-45CD-83FE-6023CDA05BA7}.Debug|x86.Build.0 = Debug|Any CPU
+		{92A29F34-D5CB-45CD-83FE-6023CDA05BA7}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{92A29F34-D5CB-45CD-83FE-6023CDA05BA7}.Release|Any CPU.Build.0 = Release|Any CPU
+		{92A29F34-D5CB-45CD-83FE-6023CDA05BA7}.Release|x64.ActiveCfg = Release|Any CPU
+		{92A29F34-D5CB-45CD-83FE-6023CDA05BA7}.Release|x64.Build.0 = Release|Any CPU
+		{92A29F34-D5CB-45CD-83FE-6023CDA05BA7}.Release|x86.ActiveCfg = Release|Any CPU
+		{92A29F34-D5CB-45CD-83FE-6023CDA05BA7}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(NestedProjects) = preSolution
+		{5D8875BD-80B3-4BE2-930E-52A60ABB341D} = {827E0CD3-B72D-47B6-A68D-7590B98EB39B}
+		{92A29F34-D5CB-45CD-83FE-6023CDA05BA7} = {0C88DD14-F956-CE84-757C-A364CCF449FC}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {E79A3DB4-C2E3-42C4-A041-5CF79B05CAD8}

--- a/Torrential.sln
+++ b/Torrential.sln
@@ -19,6 +19,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "test", "test", "{0C88DD14-F
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Torrential.Core.Tests", "test\Torrential.Core.Tests\Torrential.Core.Tests.csproj", "{92A29F34-D5CB-45CD-83FE-6023CDA05BA7}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Torrential.Harness", "src\Torrential.Harness\Torrential.Harness.csproj", "{1AA172F8-764F-459D-B2C0-019953E6B994}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -101,6 +103,18 @@ Global
 		{92A29F34-D5CB-45CD-83FE-6023CDA05BA7}.Release|x64.Build.0 = Release|Any CPU
 		{92A29F34-D5CB-45CD-83FE-6023CDA05BA7}.Release|x86.ActiveCfg = Release|Any CPU
 		{92A29F34-D5CB-45CD-83FE-6023CDA05BA7}.Release|x86.Build.0 = Release|Any CPU
+		{1AA172F8-764F-459D-B2C0-019953E6B994}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{1AA172F8-764F-459D-B2C0-019953E6B994}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{1AA172F8-764F-459D-B2C0-019953E6B994}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{1AA172F8-764F-459D-B2C0-019953E6B994}.Debug|x64.Build.0 = Debug|Any CPU
+		{1AA172F8-764F-459D-B2C0-019953E6B994}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{1AA172F8-764F-459D-B2C0-019953E6B994}.Debug|x86.Build.0 = Debug|Any CPU
+		{1AA172F8-764F-459D-B2C0-019953E6B994}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{1AA172F8-764F-459D-B2C0-019953E6B994}.Release|Any CPU.Build.0 = Release|Any CPU
+		{1AA172F8-764F-459D-B2C0-019953E6B994}.Release|x64.ActiveCfg = Release|Any CPU
+		{1AA172F8-764F-459D-B2C0-019953E6B994}.Release|x64.Build.0 = Release|Any CPU
+		{1AA172F8-764F-459D-B2C0-019953E6B994}.Release|x86.ActiveCfg = Release|Any CPU
+		{1AA172F8-764F-459D-B2C0-019953E6B994}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -108,6 +122,7 @@ Global
 	GlobalSection(NestedProjects) = preSolution
 		{5D8875BD-80B3-4BE2-930E-52A60ABB341D} = {827E0CD3-B72D-47B6-A68D-7590B98EB39B}
 		{92A29F34-D5CB-45CD-83FE-6023CDA05BA7} = {0C88DD14-F956-CE84-757C-A364CCF449FC}
+		{1AA172F8-764F-459D-B2C0-019953E6B994} = {827E0CD3-B72D-47B6-A68D-7590B98EB39B}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {E79A3DB4-C2E3-42C4-A041-5CF79B05CAD8}

--- a/src/Torrential.Core/BitConverterExtensions.cs
+++ b/src/Torrential.Core/BitConverterExtensions.cs
@@ -1,0 +1,70 @@
+using System.Buffers;
+using System.Buffers.Binary;
+
+namespace Torrential.Core;
+
+public static class BitConverterExtensions
+{
+    public static ushort ReadBigEndianUInt16(this Span<byte> buffer)
+    {
+        return BinaryPrimitives.ReadUInt16BigEndian(buffer);
+    }
+
+    public static ushort ReadBigEndianUInt16(this ReadOnlySequence<byte> sequence)
+    {
+        Span<byte> buffer = stackalloc byte[2];
+        sequence.CopyTo(buffer);
+        return BinaryPrimitives.ReadUInt16BigEndian(buffer);
+    }
+
+    public static int ReadBigEndianInt32(this Span<byte> buffer)
+    {
+        return BinaryPrimitives.ReadInt32BigEndian(buffer);
+    }
+
+    public static int ReadBigEndianInt32(this ReadOnlySequence<byte> sequence)
+    {
+        Span<byte> buffer = stackalloc byte[4];
+        sequence.CopyTo(buffer);
+        return BinaryPrimitives.ReadInt32BigEndian(buffer);
+    }
+
+    public static long ReadBigEndianInt64(this Span<byte> buffer)
+    {
+        return BinaryPrimitives.ReadInt64BigEndian(buffer);
+    }
+
+    public static long ReadBigEndianInt64(this ReadOnlySequence<byte> sequence)
+    {
+        Span<byte> buffer = stackalloc byte[8];
+        sequence.CopyTo(buffer);
+        return BinaryPrimitives.ReadInt64BigEndian(buffer);
+    }
+
+    public static bool TryWriteBigEndian(this Span<byte> buffer, int value)
+    {
+        if (buffer.Length < 4)
+            return false;
+
+        BinaryPrimitives.WriteInt32BigEndian(buffer, value);
+        return true;
+    }
+
+    public static bool TryWriteBigEndian(this Span<byte> buffer, long value)
+    {
+        if (buffer.Length < 8)
+            return false;
+
+        BinaryPrimitives.WriteInt64BigEndian(buffer, value);
+        return true;
+    }
+
+    public static bool TryWriteBigEndian(this Span<byte> buffer, uint value)
+    {
+        if (buffer.Length < 4)
+            return false;
+
+        BinaryPrimitives.WriteUInt32BigEndian(buffer, value);
+        return true;
+    }
+}

--- a/src/Torrential.Core/Bitfield.cs
+++ b/src/Torrential.Core/Bitfield.cs
@@ -1,0 +1,140 @@
+using System.Buffers;
+using System.Numerics;
+
+namespace Torrential.Core;
+
+public interface IBitfield
+{
+    int NumberOfPieces { get; }
+    ReadOnlySpan<byte> Bytes { get; }
+    float CompletionRatio { get; }
+    void Fill(Span<byte> data);
+    bool HasAll();
+    bool HasNone();
+    bool HasPiece(int index);
+    PieceSuggestionResult SuggestPieceToDownload(IBitfield peerBitfield);
+}
+
+public sealed class Bitfield : IBitfield, IDisposable
+{
+    private readonly int _numOfPieces;
+    private readonly int _sizeInBytes;
+    private readonly byte[] _bitfield;
+
+    public int NumberOfPieces => _numOfPieces;
+
+    public ReadOnlySpan<byte> Bytes => _bitfield.AsSpan().Slice(0, _sizeInBytes);
+
+    public float CompletionRatio
+    {
+        get
+        {
+            var totalPieces = (float)_numOfPieces;
+            var piecesHave = _bitfield.Sum(b => BitOperations.PopCount(b));
+            return piecesHave / totalPieces;
+        }
+    }
+
+    public Bitfield(int numOfPieces)
+    {
+        _numOfPieces = numOfPieces;
+        _sizeInBytes = (numOfPieces + 7) / 8;
+        _bitfield = ArrayPool<byte>.Shared.Rent(_sizeInBytes);
+    }
+
+    public Bitfield(Span<byte> data)
+    {
+        _sizeInBytes = data.Length;
+        _numOfPieces = _sizeInBytes * 8;
+        _bitfield = ArrayPool<byte>.Shared.Rent(_sizeInBytes);
+        data.CopyTo(_bitfield);
+    }
+
+    public Bitfield(ReadOnlySequence<byte> data)
+    {
+        _sizeInBytes = (int)data.Length;
+        _numOfPieces = _sizeInBytes * 8;
+        _bitfield = new byte[_sizeInBytes];
+        data.CopyTo(_bitfield);
+    }
+
+    public void Fill(Span<byte> data)
+    {
+        data.CopyTo(_bitfield);
+    }
+
+    public bool HasAll()
+    {
+        if (_bitfield[0] != 255)
+            return false;
+
+        var piecesHave = _bitfield.Sum(b => BitOperations.PopCount(b));
+        return piecesHave == _numOfPieces;
+    }
+
+    public bool HasNone()
+    {
+        for (int i = 0; i < _sizeInBytes; i++)
+        {
+            if (_bitfield[i] != 0)
+            {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    public bool HasPiece(int index)
+    {
+        if (index < 0 || index >= _numOfPieces)
+        {
+            throw new ArgumentOutOfRangeException(nameof(index));
+        }
+
+        var byteIndex = index / 8;
+        var bitIndex = 7 - (index % 8);
+        return (_bitfield[byteIndex] & (1 << bitIndex)) != 0;
+    }
+
+    /// <summary>
+    /// WARNING: This method is not thread-safe, and should only be called in a single-threaded context.
+    /// </summary>
+    public void MarkHave(int index)
+    {
+        if (index < 0 || index >= _numOfPieces)
+            throw new ArgumentOutOfRangeException(nameof(index));
+
+        var byteIndex = index / 8;
+        var bitIndex = 7 - (index % 8);
+        _bitfield[byteIndex] |= (byte)(1 << bitIndex);
+    }
+
+    public PieceSuggestionResult SuggestPieceToDownload(IBitfield peerBitfield)
+    {
+        if (HasAll())
+            return PieceSuggestionResult.NoMorePieces;
+
+        var random = Random.Shared.Next(0, _numOfPieces);
+
+        var hasAll = HasAll();
+        while (HasPiece(random) && !hasAll)
+        {
+            random = Random.Shared.Next(0, _numOfPieces);
+            hasAll = HasAll();
+        }
+
+        return new PieceSuggestionResult(random, !hasAll);
+    }
+
+    public void Dispose()
+    {
+        if (_bitfield != null)
+            ArrayPool<byte>.Shared.Return(_bitfield, true);
+    }
+}
+
+public readonly record struct PieceSuggestionResult(int? Index, bool MorePiecesAvailable)
+{
+    public static PieceSuggestionResult NoMorePieces { get; } = new PieceSuggestionResult(null, false);
+}

--- a/src/Torrential.Core/HandshakeService.cs
+++ b/src/Torrential.Core/HandshakeService.cs
@@ -1,0 +1,193 @@
+using Microsoft.Extensions.Logging;
+using System.Buffers;
+using System.IO.Pipelines;
+
+namespace Torrential.Core;
+
+public sealed class HandshakeService(ILogger<HandshakeService> logger)
+{
+    static readonly byte[] EMPTY_RESERVED = [0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0];
+    static ReadOnlySpan<byte> PROTOCOL_BYTES => "BitTorrent protocol"u8;
+
+    public async Task<HandshakeResponse> HandleInbound(
+        PipeWriter writer,
+        PipeReader reader,
+        PeerId selfId,
+        Func<InfoHash, bool> isValidInfoHash,
+        CancellationToken stoppingToken)
+    {
+        var response = await WaitForHandshake(reader, stoppingToken);
+        if (!response.Success)
+        {
+            logger.LogDebug("Handshake failed - {Error}", response.Error);
+            return response;
+        }
+
+        if (!isValidInfoHash(response.InfoHash))
+        {
+            logger.LogWarning("Handshake failed - Torrent not found");
+            return new HandshakeResponse(HandshakeError.INVALID_HASH);
+        }
+
+        logger.LogInformation("Handshake received");
+        await SendHandshake(writer, response.InfoHash, selfId);
+        logger.LogInformation("Handshake sent");
+        return response;
+    }
+
+    public async Task<HandshakeResponse> HandleOutbound(
+        PipeWriter writer,
+        PipeReader reader,
+        InfoHash infoHash,
+        PeerId selfId,
+        CancellationToken stoppingToken)
+    {
+        await SendHandshake(writer, infoHash, selfId);
+        var response = await WaitForHandshake(reader, stoppingToken);
+        if (response.InfoHash != infoHash)
+        {
+            logger.LogWarning("Handshake failed - Info hash did not match");
+            return new HandshakeResponse(HandshakeError.INVALID_HASH);
+        }
+
+        return response;
+    }
+
+    private async Task<HandshakeResponse> WaitForHandshake(PipeReader reader, CancellationToken cancellationToken)
+    {
+        while (!cancellationToken.IsCancellationRequested)
+        {
+            ReadOnlySequence<byte> buffer;
+            ReadResult result;
+            try
+            {
+                result = await reader.ReadAsync(cancellationToken);
+                buffer = result.Buffer;
+            }
+            catch (OperationCanceledException)
+            {
+                return new HandshakeResponse(HandshakeError.CANCELLED);
+            }
+            catch (Exception e)
+            {
+                logger.LogError(e, "Handshake error");
+                return new HandshakeResponse(HandshakeError.FATAL);
+            }
+
+            if (TryReadHandshake(ref buffer, out var handshakeBytes))
+            {
+                var resp = ParseHandshake(ref handshakeBytes);
+                reader.AdvanceTo(buffer.Start, buffer.End);
+                return resp;
+            }
+            else
+            {
+                reader.AdvanceTo(buffer.Start, buffer.End);
+            }
+
+            if (result.IsCompleted)
+            {
+                break;
+            }
+        }
+
+        logger.LogDebug("Handshake timed out");
+        return new HandshakeResponse(HandshakeError.NO_RESPONSE);
+    }
+
+    private async ValueTask SendHandshake(PipeWriter writer, InfoHash infoHash, PeerId selfId)
+    {
+        WriteHandshake(writer, infoHash, selfId);
+        await writer.FlushAsync();
+    }
+
+    internal static void WriteHandshake(PipeWriter writer, InfoHash infoHash, PeerId selfId)
+    {
+        var buffer = writer.GetSpan(68);
+        buffer[0] = 19;
+        PROTOCOL_BYTES.CopyTo(buffer[1..]);
+        EMPTY_RESERVED.CopyTo(buffer[20..]);
+        infoHash.CopyTo(buffer[28..]);
+        selfId.CopyTo(buffer[48..]);
+        writer.Advance(68);
+    }
+
+    private static bool TryReadHandshake(ref ReadOnlySequence<byte> buffer, out ReadOnlySequence<byte> handshakeBytes)
+    {
+        var sequenceReader = new SequenceReader<byte>(buffer);
+        if (!sequenceReader.TryReadExact(68, out handshakeBytes))
+            return false;
+
+        buffer = buffer.Slice(handshakeBytes.End);
+        return true;
+    }
+
+    internal static HandshakeResponse ParseHandshake(ref ReadOnlySequence<byte> handshakeBytes)
+    {
+        var reader = new SequenceReader<byte>(handshakeBytes);
+
+        if (!reader.TryRead(out var firstByte))
+            return new HandshakeResponse(HandshakeError.NO_DATA);
+
+        if (firstByte != 19)
+            return new HandshakeResponse(HandshakeError.INVALID_FIRST_BYTE);
+
+        if (!reader.TryReadExact(19, out var protocolSequence))
+            return new HandshakeResponse(HandshakeError.PROTOCOL_NOT_RECEIVED);
+
+        Span<byte> protocolBuff = stackalloc byte[19];
+        protocolSequence.CopyTo(protocolBuff);
+        if (!protocolBuff.SequenceEqual(PROTOCOL_BYTES))
+            return new HandshakeResponse(HandshakeError.INVALID_PROTOCOL);
+
+        if (!reader.TryReadPeerExtensions(out var peerExtensions))
+            return new HandshakeResponse(HandshakeError.RESERVED_NOT_RECEIVED);
+
+        if (!reader.TryReadInfoHash(out var peerInfoHash))
+            return new HandshakeResponse(HandshakeError.HASH_NOT_RECEIVED);
+
+        if (!reader.TryReadPeerId(out var peerId))
+            return new HandshakeResponse(HandshakeError.PEER_ID_NOT_RECEIVED);
+
+        return new HandshakeResponse(peerInfoHash, peerId, peerExtensions);
+    }
+}
+
+public readonly struct HandshakeResponse
+{
+    public readonly bool Success;
+    public readonly HandshakeError Error = HandshakeError.NONE;
+    public readonly PeerId PeerId;
+    public readonly PeerExtensions Extensions;
+    public readonly InfoHash InfoHash;
+
+    public HandshakeResponse(InfoHash infoHash, PeerId peerId, PeerExtensions extensions)
+    {
+        Success = true;
+        PeerId = peerId;
+        Extensions = extensions;
+        InfoHash = infoHash;
+    }
+
+    public HandshakeResponse(HandshakeError error)
+    {
+        Success = false;
+        Error = error;
+    }
+}
+
+public enum HandshakeError : byte
+{
+    NONE,
+    NO_RESPONSE,
+    NO_DATA,
+    INVALID_FIRST_BYTE,
+    PROTOCOL_NOT_RECEIVED,
+    INVALID_PROTOCOL,
+    RESERVED_NOT_RECEIVED,
+    HASH_NOT_RECEIVED,
+    INVALID_HASH,
+    PEER_ID_NOT_RECEIVED,
+    CANCELLED,
+    FATAL = byte.MaxValue,
+}

--- a/src/Torrential.Core/IPeerWireConnection.cs
+++ b/src/Torrential.Core/IPeerWireConnection.cs
@@ -1,0 +1,16 @@
+using System.IO.Pipelines;
+
+namespace Torrential.Core;
+
+public interface IPeerWireConnection : IAsyncDisposable
+{
+    Guid Id { get; }
+    PeerInfo PeerInfo { get; }
+    PeerId? PeerId { get; }
+    PipeReader Reader { get; }
+    PipeWriter Writer { get; }
+    InfoHash InfoHash { get; }
+    void SetInfoHash(InfoHash infoHash);
+    void SetPeerId(PeerId peerId);
+    DateTimeOffset ConnectionTimestamp { get; }
+}

--- a/src/Torrential.Core/InfoHash.cs
+++ b/src/Torrential.Core/InfoHash.cs
@@ -1,0 +1,148 @@
+using System.Collections.Concurrent;
+using System.Diagnostics.CodeAnalysis;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace Torrential.Core;
+
+[JsonConverter(typeof(InfoHashJsonConverter))]
+public readonly record struct InfoHash(long P1, long P2, int P3) : IParsable<InfoHash>
+{
+    private static ConcurrentDictionary<InfoHash, string> _stringCache = new();
+
+    public static readonly InfoHash None = new InfoHash(long.MaxValue, long.MaxValue, int.MaxValue);
+
+    public static implicit operator InfoHash(string value) => FromHexString(value);
+    public static implicit operator string(InfoHash value) => value.AsString();
+
+    public static InfoHash FromSpan(Span<byte> buffer) =>
+        new InfoHash(
+            buffer.ReadBigEndianInt64(),
+            buffer[8..].ReadBigEndianInt64(),
+            buffer[16..].ReadBigEndianInt32());
+
+
+    public static InfoHash FromHexString(ReadOnlySpan<char> hexString)
+    {
+        if (hexString == null || hexString.Length != 40)
+            throw new ArgumentException("Input string must be a valid hexadecimal string and have a length of 40.");
+
+        Span<byte> buffer = new byte[20];
+        for (int i = 0; i < hexString.Length; i += 2)
+        {
+            int highDigit = FromHexChar(hexString[i]);
+            int lowDigit = FromHexChar(hexString[i + 1]);
+            buffer[i / 2] = (byte)((highDigit << 4) | lowDigit);
+        }
+
+        return FromSpan(buffer);
+    }
+
+    public void CopyTo(Span<byte> buffer)
+    {
+        buffer.TryWriteBigEndian(P1);
+        buffer[8..].TryWriteBigEndian(P2);
+        buffer[16..].TryWriteBigEndian(P3);
+    }
+
+    public void WriteUrlEncodedHash(Span<char> destination)
+    {
+        Span<byte> buffer = stackalloc byte[20];
+        CopyTo(buffer);
+        UrlEncodeHash(buffer, destination);
+    }
+
+    private static void UrlEncodeHash(Span<byte> hash, Span<char> encoded)
+    {
+        for (int i = 0; i < hash.Length; i++)
+        {
+            encoded[i * 3] = '%';
+            encoded[(i * 3) + 1] = HexDigit(hash[i] >> 4);
+            encoded[(i * 3) + 2] = HexDigit(hash[i] & 0x0F);
+        }
+    }
+
+    private static char HexDigit(int value) => (char)(value < 10 ? '0' + value : 'A' + value - 10);
+    private static int FromHexChar(char hexChar)
+    {
+        if (hexChar >= '0' && hexChar <= '9')
+            return hexChar - '0';
+        else if (hexChar >= 'A' && hexChar <= 'F')
+            return 10 + (hexChar - 'A');
+        else if (hexChar >= 'a' && hexChar <= 'f')
+            return 10 + (hexChar - 'a');
+        else
+            throw new ArgumentException("Invalid hexadecimal character.");
+    }
+
+    public string AsString()
+    {
+        //Check the cache first, to avoid the allocation
+        if (_stringCache.TryGetValue(this, out var cached))
+            return cached;
+
+
+        Span<byte> hash = stackalloc byte[20];
+        CopyTo(hash);
+
+        Span<char> encoded = stackalloc char[40];
+        for (int i = 0; i < hash.Length; i++)
+        {
+            encoded[i * 2] = HexDigit(hash[i] >> 4);
+            encoded[(i * 2) + 1] = HexDigit(hash[i] & 0x0F);
+        }
+        var str = new string(encoded);
+        _stringCache.TryAdd(this, str);
+        return str;
+    }
+
+    public void CopyHexString(Span<char> destination)
+    {
+        Span<byte> hash = stackalloc byte[20];
+        CopyTo(hash);
+
+        Span<char> encoded = stackalloc char[40];
+        for (int i = 0; i < hash.Length; i++)
+        {
+            encoded[i * 2] = HexDigit(hash[i] >> 4);
+            encoded[(i * 2) + 1] = HexDigit(hash[i] & 0x0F);
+        }
+
+        encoded.CopyTo(destination);
+    }
+
+
+    public static InfoHash Parse(string s, IFormatProvider? provider) =>
+          FromHexString(s);
+
+    public static bool TryParse([NotNullWhen(true)] string? s, IFormatProvider? provider, [MaybeNullWhen(false)] out InfoHash result)
+    {
+        try
+        {
+            result = FromHexString(s);
+            return true;
+        }
+        catch
+        {
+            result = None;
+            return false;
+        }
+    }
+}
+
+public class InfoHashJsonConverter : JsonConverter<InfoHash>
+{
+    public override InfoHash Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+    {
+        Span<char> chars = stackalloc char[40];
+        reader.CopyString(chars);
+        return InfoHash.FromHexString(chars);
+    }
+
+    public override void Write(Utf8JsonWriter writer, InfoHash value, JsonSerializerOptions options)
+    {
+        Span<char> chars = stackalloc char[40];
+        value.CopyHexString(chars);
+        writer.WriteStringValue(chars);
+    }
+}

--- a/src/Torrential.Core/MessagePacker.cs
+++ b/src/Torrential.Core/MessagePacker.cs
@@ -1,0 +1,126 @@
+using System.Buffers;
+
+namespace Torrential.Core;
+
+public static class MessagePacker
+{
+    public static PreparedPacket Pack(byte messageId)
+    {
+        var pak = new PreparedPacket(5);
+        var buffer = pak.AsSpan();
+        buffer.TryWriteBigEndian(1);
+        buffer[4] = messageId;
+        return pak;
+    }
+
+    public static PreparedPacket Pack(byte messageId, int p1)
+    {
+        var pak = new PreparedPacket(9);
+        var buffer = pak.AsSpan();
+        buffer.TryWriteBigEndian(5);
+        buffer[4] = messageId;
+        buffer[5..].TryWriteBigEndian(p1);
+        return pak;
+    }
+
+    public static PreparedPacket Pack(byte messageId, int p1, int p2)
+    {
+        var pak = new PreparedPacket(13);
+        var buffer = pak.AsSpan();
+        buffer.TryWriteBigEndian(9);
+        buffer[4] = messageId;
+        buffer[5..].TryWriteBigEndian(p1);
+        buffer[9..].TryWriteBigEndian(p2);
+        return pak;
+    }
+
+    public static PreparedPacket Pack(byte messageId, int p1, int p2, int p3)
+    {
+        var pak = new PreparedPacket(17);
+        var buffer = pak.AsSpan();
+        buffer.TryWriteBigEndian(13);
+        buffer[4] = messageId;
+        buffer[5..].TryWriteBigEndian(p1);
+        buffer[9..].TryWriteBigEndian(p2);
+        buffer[13..].TryWriteBigEndian(p3);
+        return pak;
+    }
+
+    public static PreparedPacket Pack(int pieceIndex, int begin, ReadOnlySequence<byte> pieceData)
+    {
+        var pak = new PreparedPacket(13 + (int)pieceData.Length);
+        var buffer = pak.AsSpan();
+        buffer.TryWriteBigEndian(9 + (int)pieceData.Length);
+        buffer[4] = PeerWireMessageType.Piece;
+        buffer[5..].TryWriteBigEndian(pieceIndex);
+        buffer[9..].TryWriteBigEndian(begin);
+        pieceData.CopyTo(buffer.Slice(13));
+        return pak;
+    }
+
+    public static PreparedPacket Pack(int pieceIndex, int begin, ReadOnlySpan<byte> pieceData)
+    {
+        var pak = new PreparedPacket(13 + pieceData.Length);
+        var buffer = pak.AsSpan();
+        buffer.TryWriteBigEndian(9 + pieceData.Length);
+        buffer[4] = PeerWireMessageType.Piece;
+        buffer[5..].TryWriteBigEndian(pieceIndex);
+        buffer[9..].TryWriteBigEndian(begin);
+        pieceData.CopyTo(buffer.Slice(13));
+        return pak;
+    }
+
+    public static PreparedPacket PackBitfield(ReadOnlySequence<byte> bitfieldData)
+    {
+        var bitfieldLength = (int)bitfieldData.Length;
+        var pak = new PreparedPacket(5 + bitfieldLength);
+        var buffer = pak.AsSpan();
+        buffer.TryWriteBigEndian(bitfieldLength + 1);
+        buffer[4] = PeerWireMessageType.Bitfield;
+        bitfieldData.CopyTo(buffer[5..]);
+        return pak;
+    }
+
+    public static PreparedPacket PackBitfield(ReadOnlySpan<byte> bitfieldData)
+    {
+        var bitfieldLength = (int)bitfieldData.Length;
+        var pak = new PreparedPacket(5 + bitfieldLength);
+        var buffer = pak.AsSpan();
+        buffer.TryWriteBigEndian(bitfieldLength + 1);
+        buffer[4] = PeerWireMessageType.Bitfield;
+        bitfieldData.CopyTo(buffer[5..]);
+        return pak;
+    }
+
+    public static PreparedPacket Pack(IBitfield bitfield)
+    {
+        var pak = new PreparedPacket(bitfield.Bytes.Length + 5);
+        var buffer = pak.AsSpan();
+        buffer.TryWriteBigEndian(bitfield.Bytes.Length + 1);
+        buffer[4] = PeerWireMessageType.Bitfield;
+        bitfield.Bytes.CopyTo(buffer[5..]);
+        return pak;
+    }
+
+    public static PreparedPacket? Pack(int messageSize, byte messageId, ReadOnlySequence<byte> payload)
+    {
+        switch (messageId)
+        {
+            case PeerWireMessageType.Choke:
+            case PeerWireMessageType.Unchoke:
+            case PeerWireMessageType.Interested:
+            case PeerWireMessageType.NotInterested:
+                return Pack(messageId);
+            case PeerWireMessageType.Have:
+                return Pack(messageId, payload.Slice(0, 4).ReadBigEndianInt32());
+            case PeerWireMessageType.Request:
+                return Pack(messageId, payload.Slice(0, 4).ReadBigEndianInt32(), payload.Slice(4, 4).ReadBigEndianInt32(), payload.Slice(8, 4).ReadBigEndianInt32());
+            case PeerWireMessageType.Piece:
+                return Pack(payload.Slice(0, 4).ReadBigEndianInt32(), payload.Slice(4, 4).ReadBigEndianInt32(), payload.Slice(8));
+            case PeerWireMessageType.Bitfield:
+                return PackBitfield(payload);
+            default:
+                return null;
+        }
+    }
+}

--- a/src/Torrential.Core/PeerExtensions.cs
+++ b/src/Torrential.Core/PeerExtensions.cs
@@ -1,0 +1,21 @@
+namespace Torrential.Core;
+
+public readonly record struct PeerExtensions(byte B1, byte B2, byte B3, byte B4, byte B5, byte B6, byte B7, byte B8)
+{
+    public static PeerExtensions None { get; } = new(0, 0, 0, 0, 0, 0, 0, 0);
+
+    public static PeerExtensions FromLong(long extensions)
+    {
+        Span<byte> extensionBytes = stackalloc byte[8];
+        extensionBytes.TryWriteBigEndian(extensions);
+        return new(
+            extensionBytes[0],
+            extensionBytes[1],
+            extensionBytes[2],
+            extensionBytes[3],
+            extensionBytes[4],
+            extensionBytes[5],
+            extensionBytes[6],
+            extensionBytes[7]);
+    }
+}

--- a/src/Torrential.Core/PeerId.cs
+++ b/src/Torrential.Core/PeerId.cs
@@ -1,0 +1,130 @@
+using System.Text;
+
+namespace Torrential.Core;
+
+public readonly record struct PeerId(long P1, long P2, int P3)
+{
+    private static readonly ushort TorrentialImplementation = CreateImplementationShort('T', 'O');
+    public static PeerId None { get; } = new(long.MaxValue, long.MaxValue, int.MaxValue);
+
+    public static implicit operator string(PeerId value) => value.ToAsciiString();
+
+    public static PeerId From(ReadOnlySpan<byte> span)
+    {
+        Span<byte> buffer = stackalloc byte[span.Length];
+        span.CopyTo(buffer);
+        return new(buffer.ReadBigEndianInt64(), buffer[8..].ReadBigEndianInt64(), buffer[16..].ReadBigEndianInt32());
+    }
+
+    public static PeerId From(Span<byte> buffer) =>
+        new(buffer.ReadBigEndianInt64(), buffer[8..].ReadBigEndianInt64(), buffer[16..].ReadBigEndianInt32());
+
+    public static PeerId New =>
+        FromConvention(TorrentialImplementation, '0', '1', '0', '0');
+
+    public static PeerId WithPrefix(ReadOnlySpan<byte> prefix)
+    {
+        Span<byte> buffer = stackalloc byte[20];
+        prefix[0..Math.Min(prefix.Length, 20)].CopyTo(buffer);
+
+        var bytesToFill = 20 - Math.Min(20, prefix.Length);
+        if (bytesToFill != 0)
+            Random.Shared.NextBytes(buffer[bytesToFill..]);
+
+        return PeerId.From(buffer);
+    }
+
+    public string ToAsciiString()
+    {
+        Span<byte> buffer = stackalloc byte[20];
+        buffer.TryWriteBigEndian(P1);
+        buffer[8..].TryWriteBigEndian(P2);
+        buffer[16..].TryWriteBigEndian(P3);
+        return Encoding.ASCII.GetString(buffer);
+    }
+
+    public void CopyTo(Span<byte> buffer)
+    {
+        buffer.TryWriteBigEndian(P1);
+        buffer[8..].TryWriteBigEndian(P2);
+        buffer[16..].TryWriteBigEndian(P3);
+    }
+
+    public bool FollowsConvention()
+    {
+        Span<byte> buffer = stackalloc byte[8];
+        buffer.TryWriteBigEndian(P1);
+        return buffer switch
+        {
+        [(byte)'-', var cli1, var cli2, var v1, var v2, var v3, var v4, (byte)'-', _]
+            when
+                IsChar(cli1)
+                && IsChar(cli2)
+                && IsValidVersionByte(v1)
+                && IsValidVersionByte(v2)
+                && IsValidVersionByte(v3)
+                && IsValidVersionByte(v4)
+          => true,
+            _ => false
+        };
+    }
+
+    private static bool IsChar(byte b)
+    {
+        if (b >= 'A' && b <= 'Z') return true;
+        if (b >= 'a' && b <= 'z') return true;
+        return false;
+    }
+    private static bool IsDigit(byte b)
+    {
+        if (b >= '0' && b <= '9') return true;
+        return false;
+    }
+    private static bool IsValidVersionByte(byte b)
+    {
+        if (IsChar(b)) return true;
+        if (IsDigit(b)) return true;
+        if (b == '.') return true;
+        if (b == '-') return true;
+        return false;
+
+    }
+
+    private static ushort CreateImplementationShort(char a, char b) => (ushort)(((byte)a << 8) | (byte)b);
+    private static PeerId FromConvention(ushort implementation, char v1, char v2, char v3, char v4)
+    {
+        Span<byte> p1Span = stackalloc byte[8]
+        {
+            (byte)'-',
+            (byte)(implementation >> 8),
+            (byte)(implementation & 0xff),
+            (byte)v1,
+            (byte)v2,
+            (byte)v3,
+            (byte)v4,
+            (byte)'-'
+        };
+
+        Span<byte> p2Span = stackalloc byte[8]
+        {
+            (byte)(char)Random.Shared.Next('0', '9' + 1),
+            (byte)(char)Random.Shared.Next('0', '9' + 1),
+            (byte)(char)Random.Shared.Next('0', '9' + 1),
+            (byte)(char)Random.Shared.Next('0', '9' + 1),
+            (byte)(char)Random.Shared.Next('0', '9' + 1),
+            (byte)(char)Random.Shared.Next('0', '9' + 1),
+            (byte)(char)Random.Shared.Next('0', '9' + 1),
+            (byte)(char)Random.Shared.Next('0', '9' + 1),
+        };
+
+        Span<byte> p3Span = stackalloc byte[4]
+        {
+            (byte)(char)Random.Shared.Next('0', '9' + 1),
+            (byte)(char)Random.Shared.Next('0', '9' + 1),
+            (byte)(char)Random.Shared.Next('0', '9' + 1),
+            (byte)(char)Random.Shared.Next('0', '9' + 1),
+        };
+
+        return new PeerId(p1Span.ReadBigEndianInt64(), p2Span.ReadBigEndianInt64(), p3Span.ReadBigEndianInt32());
+    }
+}

--- a/src/Torrential.Core/PeerInfo.cs
+++ b/src/Torrential.Core/PeerInfo.cs
@@ -1,0 +1,5 @@
+using System.Net;
+
+namespace Torrential.Core;
+
+public readonly record struct PeerInfo(IPAddress Ip, int Port);

--- a/src/Torrential.Core/PeerWireClient.cs
+++ b/src/Torrential.Core/PeerWireClient.cs
@@ -1,0 +1,385 @@
+using Microsoft.Extensions.Logging;
+using System.Buffers;
+using System.IO.Pipelines;
+using System.Threading.Channels;
+
+namespace Torrential.Core;
+
+public sealed class PeerWireClient : IAsyncDisposable
+{
+    private const int DEFAULT_BLOCK_SIZE = 16384;
+    private readonly PeerWireState _state;
+    private readonly CancellationTokenSource _cts;
+    private readonly IPeerWireConnection _connection;
+    private readonly ILogger _logger;
+    private readonly int _numberOfPieces;
+    private readonly InfoHash _infoHash;
+
+    public PeerInfo PeerInfo => _connection.PeerInfo;
+
+    private readonly Channel<PreparedPacket> _outboundMessages = Channel.CreateBounded<PreparedPacket>(new BoundedChannelOptions(10)
+    {
+        FullMode = BoundedChannelFullMode.Wait,
+        SingleReader = true,
+        SingleWriter = false
+    });
+
+    private readonly Channel<PooledBlock> _inboundBlocks = Channel.CreateBounded<PooledBlock>(new BoundedChannelOptions(10)
+    {
+        SingleReader = false,
+        SingleWriter = true
+    });
+
+    public readonly Channel<PieceRequestMessage> PeerPieceRequests = Channel.CreateBounded<PieceRequestMessage>(new BoundedChannelOptions(5)
+    {
+        SingleReader = false,
+        SingleWriter = true,
+        FullMode = BoundedChannelFullMode.Wait
+    });
+
+    public ChannelReader<PooledBlock> InboundBlocks => _inboundBlocks.Reader;
+
+    public PeerWireState State => _state;
+
+    public long BytesUploaded { get; private set; }
+    public long BytesDownloaded { get; private set; }
+    public PeerId PeerId { get; private set; }
+
+    public DateTimeOffset LastMessageTimestamp { get; private set; }
+
+    public PeerWireClient(IPeerWireConnection connection, int numberOfPieces, ILogger logger, CancellationToken stoppingToken)
+    {
+        if (!connection.PeerId.HasValue)
+            throw new ArgumentException("Peer Id must be set", nameof(connection));
+
+        LastMessageTimestamp = connection.ConnectionTimestamp;
+        PeerId = connection.PeerId.Value;
+
+        _cts = CancellationTokenSource.CreateLinkedTokenSource(stoppingToken);
+        _state = new PeerWireState();
+
+        _connection = connection;
+        _logger = logger;
+        _infoHash = connection.InfoHash;
+        _numberOfPieces = numberOfPieces;
+        _state.PeerBitfield = new Bitfield(_numberOfPieces);
+    }
+
+
+    public async Task ProcessMessages()
+    {
+        var readerTask = ProcessReads(_cts.Token);
+        var writeTask = ProcessWrites(_cts.Token);
+
+        try
+        {
+            await Task.WhenAll(readerTask, writeTask);
+        }
+        catch (OperationCanceledException) { }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Error processing peer connection {PeerId}", PeerId);
+        }
+
+
+        _outboundMessages.Writer.Complete();
+        _inboundBlocks.Writer.Complete();
+        PeerPieceRequests.Writer.Complete();
+
+        //Clear out any disposables stuck in the channels
+        await foreach (var pak in _outboundMessages.Reader.ReadAllAsync())
+            pak.Dispose();
+
+        await foreach (var pak in _inboundBlocks.Reader.ReadAllAsync())
+            pak.Dispose();
+
+        await foreach (var _ in PeerPieceRequests.Reader.ReadAllAsync()) ;
+    }
+
+    private async Task ProcessWrites(CancellationToken cancellationToken)
+    {
+        try
+        {
+
+            await foreach (var pak in _outboundMessages.Reader.ReadAllAsync(cancellationToken))
+            {
+                using (pak)
+                {
+                    try
+                    {
+                        _connection.Writer.Write(pak.AsSpan());
+                        await _connection.Writer.FlushAsync(cancellationToken);
+                    }
+                    catch (Exception ex)
+                    {
+                        _logger.LogError("Failed to write message to {PeerId} - ending peer connection write processor", PeerId);
+                        return;
+                    }
+                }
+            }
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Error processing writes");
+        }
+
+        _logger.LogInformation("Ending peer connection write processor");
+
+    }
+
+    private async Task ProcessReads(CancellationToken cancellationToken)
+    {
+        //TODO - enforce global and peer rate limits here
+        while (!cancellationToken.IsCancellationRequested)
+        {
+            try
+            {
+                ReadResult result = await _connection.Reader.ReadAsync(cancellationToken);
+                ReadOnlySequence<byte> buffer = result.Buffer;
+
+                while (TryReadMessage(ref buffer, out var messageSize, out var messageId, out ReadOnlySequence<byte> payload))
+                {
+                    if (!await ProcessAsync(messageSize, messageId, payload))
+                    {
+                        _logger.LogInformation("Failed to process message {MessageId} {MessageSize} - ending peer connection read processor", messageId, messageSize);
+                        return;
+                    }
+                }
+
+                // Tell the PipeReader how much of the buffer has been consumed.
+                _connection.Reader.AdvanceTo(buffer.Start, buffer.End);
+
+                // Stop reading if there's no more data coming.
+                if (result.IsCompleted)
+                {
+                    _logger.LogWarning("No further data from peer");
+                    return;
+                }
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Error reading from peer");
+                return;
+            }
+        }
+
+        _logger.LogInformation("Ending peer connection read processor");
+    }
+
+    internal static bool TryReadMessage(ref ReadOnlySequence<byte> buffer, out int messageSize, out byte messageId, out ReadOnlySequence<byte> payload)
+    {
+        payload = default;
+        messageId = 0;
+        messageSize = 0;
+
+        //Make sure that we have at least 4 bytes
+        //4 for the message size (32-bit) unsigned int
+        if (buffer.Length < 4)
+            return false;
+
+        var sequenceReader = new SequenceReader<byte>(buffer);
+        if (!sequenceReader.TryReadBigEndian(out messageSize))
+            return false;
+
+        if (messageSize == 0)
+        {
+            buffer = buffer.Slice(4);
+            return true;
+        }
+
+        if (!sequenceReader.TryRead(out messageId))
+            return false;
+
+        if (messageSize == 1)
+        {
+            buffer = buffer.Slice(5);
+            return true;
+        }
+        else if (!sequenceReader.TryReadExact(messageSize - 1, out payload))
+        {
+            return false;
+        }
+
+        buffer = buffer.Slice(payload.End);
+        return true;
+    }
+
+    private async ValueTask<bool> ProcessAsync(int messageSize, byte messageId, ReadOnlySequence<byte> payload)
+    {
+        //Discard keep alive messages
+        if (messageId == 0 && messageSize == 0)
+        {
+            LastMessageTimestamp = DateTimeOffset.UtcNow;
+            return true;
+        }
+
+
+        //Certain messages can be processed immediately, so we'll handle those upfront
+        bool handled;
+        switch (messageId)
+        {
+            case PeerWireMessageType.Choke:
+                HandleChoke();
+                handled = true;
+                break;
+            case PeerWireMessageType.Unchoke:
+                HandleUnchoke();
+                handled = true;
+                break;
+            case PeerWireMessageType.Interested:
+                HandleInterested();
+                handled = true;
+                break;
+            case PeerWireMessageType.NotInterested:
+                HandleNotInterested();
+                handled = true;
+                break;
+            case PeerWireMessageType.Bitfield:
+                HandleBitfield(payload);
+                handled = true;
+                break;
+            case PeerWireMessageType.Have:
+                HandleHave(payload);
+                handled = true;
+                break;
+            case PeerWireMessageType.Piece:
+                handled = await HandlePieceAsync(payload, messageSize - 9);
+                break;
+            case PeerWireMessageType.Request:
+                handled = await HandleRequestAsync(payload);
+                break;
+            case PeerWireMessageType.Cancel:
+                handled = HandleCancel(payload);
+                break;
+            default:
+                _logger.LogWarning("Unhandled message type {MessageType}", messageId);
+                handled = true;
+                break;
+        }
+
+        LastMessageTimestamp = DateTimeOffset.UtcNow;
+        return handled;
+    }
+
+    //These methods modify peer wire state and can be called from the main loop
+    private bool HandleChoke()
+    {
+        _state.AmChoked = true;
+        _state.LastChokedAt = DateTime.UtcNow;
+        return true;
+    }
+    private bool HandleUnchoke()
+    {
+        _state.AmChoked = false;
+        return true;
+    }
+    private bool HandleInterested()
+    {
+        _state.PeerInterested = true;
+        _state.PeerLastInterestedAt = DateTime.UtcNow;
+        return true;
+    }
+    private bool HandleNotInterested()
+    {
+        _state.PeerInterested = false;
+        return true;
+    }
+    private bool HandleHave(ReadOnlySequence<byte> payload)
+    {
+        var sequenceReader = new SequenceReader<byte>(payload);
+        if (!sequenceReader.TryReadBigEndian(out int index))
+            return false;
+
+        _state.PeerBitfield?.MarkHave(index);
+        return true;
+    }
+    private bool HandleBitfield(ReadOnlySequence<byte> payload)
+    {
+        Span<byte> buffer = stackalloc byte[(int)payload.Length];
+        payload.CopyTo(buffer);
+        var bitfield = new Bitfield(_numberOfPieces);
+        bitfield.Fill(buffer);
+        _state.PeerBitfield = bitfield;
+        return true;
+    }
+
+
+    //This should be placed into a request channel and processed sequentially in a separate thread
+    private async ValueTask<bool> HandleRequestAsync(ReadOnlySequence<byte> payload)
+    {
+        var pieceRequest = PieceRequestMessage.FromReadOnlySequence(payload);
+        await PeerPieceRequests.Writer.WriteAsync(pieceRequest);
+        return true;
+    }
+
+    private async ValueTask<bool> HandlePieceAsync(ReadOnlySequence<byte> payload, int chunkSize)
+    {
+        var block = PooledBlock.FromReadOnlySequence(payload, chunkSize, _infoHash);
+        await _inboundBlocks.Writer.WriteAsync(block, _cts.Token);
+        BytesDownloaded += block.Buffer.Length;
+        return true;
+    }
+
+    private bool HandleCancel(ReadOnlySequence<byte> payload)
+    {
+        var sequenceReader = new SequenceReader<byte>(payload);
+        if (!sequenceReader.TryReadBigEndian(out int index))
+            return false;
+        if (!sequenceReader.TryReadBigEndian(out int begin))
+            return false;
+        if (!sequenceReader.TryReadBigEndian(out int length))
+            return false;
+
+        return true;
+    }
+
+    private bool HandlePort(ReadOnlySequence<byte> payload)
+    {
+        var reader = new SequenceReader<byte>(payload);
+        if (!reader.TryReadBigEndian(out short port))
+            return false;
+        return true;
+    }
+
+
+    public async Task SendBitfield(IBitfield bitfield) => await WriteBitfieldAsync(bitfield);
+    public async Task SendInterested() => await SendMessageAsync(PeerWireMessageType.Interested);
+    public async Task SendNotInterested() => await SendMessageAsync(PeerWireMessageType.NotInterested);
+    public async Task SendChoke() => await SendMessageAsync(PeerWireMessageType.Choke);
+    public async Task SendUnchoke() => await SendMessageAsync(PeerWireMessageType.Unchoke);
+    public async Task SendHave(int pieceIndex) => await SendMessageAsync(PeerWireMessageType.Have, pieceIndex);
+    public async Task SendPieceRequest(int pieceIndex, int begin, int length = DEFAULT_BLOCK_SIZE) =>
+        await SendMessageAsync(PeerWireMessageType.Request, pieceIndex, begin, length);
+
+    public async Task SendPiece(PreparedPacket pak)
+    {
+        await _outboundMessages.Writer.WriteAsync(pak, _cts.Token);
+        BytesUploaded += pak.Size - 13;
+    }
+
+    public async Task SendCancel(int pieceIndex, int begin, int length) => await SendMessageAsync(PeerWireMessageType.Cancel, pieceIndex, begin, length);
+
+    private async Task SendMessageAsync(byte messageId) => await WritePacketAsync(messageId);
+    private async Task SendMessageAsync(byte messageId, int p1) => await WritePacketAsync(messageId, p1);
+    private async Task SendMessageAsync(byte messageId, int p1, int p2) => await WritePacketAsync(messageId, p1, p2);
+    private async Task SendMessageAsync(byte messageId, int p1, int p2, int p3) => await WritePacketAsync(messageId, p1, p2, p3);
+
+    private async Task WriteBitfieldAsync(IBitfield bitfield) =>
+        await _outboundMessages.Writer.WriteAsync(MessagePacker.Pack(bitfield), _cts.Token);
+    private async Task WritePacketAsync(byte messageId) =>
+        await _outboundMessages.Writer.WriteAsync(MessagePacker.Pack(messageId), _cts.Token);
+    private async Task WritePacketAsync(byte messageId, int p1) =>
+        await _outboundMessages.Writer.WriteAsync(MessagePacker.Pack(messageId, p1), _cts.Token);
+    private async Task WritePacketAsync(byte messageId, int p1, int p2) =>
+        await _outboundMessages.Writer.WriteAsync(MessagePacker.Pack(messageId, p1, p2), _cts.Token);
+    private async Task WritePacketAsync(byte messageId, int p1, int p2, int p3) =>
+        await _outboundMessages.Writer.WriteAsync(MessagePacker.Pack(messageId, p1, p2, p3), _cts.Token);
+
+
+    public async ValueTask DisposeAsync()
+    {
+        _logger.LogDebug("Disposing peer client {PeerId}", PeerId);
+        _cts.Cancel();
+        await _connection.DisposeAsync();
+    }
+}

--- a/src/Torrential.Core/PeerWireMessageType.cs
+++ b/src/Torrential.Core/PeerWireMessageType.cs
@@ -1,0 +1,29 @@
+namespace Torrential.Core;
+
+public static class PeerWireMessageType
+{
+    public const byte Choke = 0;
+    public const byte Unchoke = 1;
+    public const byte Interested = 2;
+    public const byte NotInterested = 3;
+    public const byte Have = 4;
+    public const byte Bitfield = 5;
+    public const byte Request = 6;
+    public const byte Piece = 7;
+    public const byte Cancel = 8;
+    public const byte Port = 9;
+}
+
+public enum PeerWireMessageId : byte
+{
+    Choke = 0,
+    Unchoke = 1,
+    Interested = 2,
+    NotInterested = 3,
+    Have = 4,
+    Bitfield = 5,
+    Request = 6,
+    Piece = 7,
+    Cancel = 8,
+    Port = 9
+}

--- a/src/Torrential.Core/PeerWireSocketConnection.cs
+++ b/src/Torrential.Core/PeerWireSocketConnection.cs
@@ -1,0 +1,155 @@
+using Microsoft.Extensions.Logging;
+using System.IO.Pipelines;
+using System.Net;
+using System.Net.Sockets;
+
+namespace Torrential.Core;
+
+public class PeerWireSocketConnection : IPeerWireConnection
+{
+    private readonly Socket _socket;
+    private readonly Pipe _ingressPipe;
+    private readonly Task _ingressFillTask;
+    private readonly Pipe _egressPipe;
+    private readonly Task _egressFillTask;
+    private readonly ILogger _logger;
+    private readonly CancellationTokenSource _cts;
+    private readonly Action<InfoHash, int>? _onIngressBytes;
+    private readonly Action<InfoHash, int>? _onEgressBytes;
+
+    public Guid Id { get; }
+    public PeerInfo PeerInfo { get; }
+    public PeerId? PeerId { get; private set; }
+    public InfoHash InfoHash { get; private set; } = InfoHash.None;
+    public DateTimeOffset ConnectionTimestamp { get; }
+    public PipeReader Reader { get; }
+    public PipeWriter Writer { get; }
+
+    public PeerWireSocketConnection(
+        Socket socket,
+        ILogger logger,
+        Action<InfoHash, int>? onIngressBytes = null,
+        Action<InfoHash, int>? onEgressBytes = null)
+    {
+        Id = Guid.NewGuid();
+        _socket = socket;
+        _logger = logger;
+        _onIngressBytes = onIngressBytes;
+        _onEgressBytes = onEgressBytes;
+        _cts = new CancellationTokenSource();
+
+        // Data flow from the socket to the pipe
+        _ingressPipe = PipePool.Shared.Get();
+        _ingressFillTask = IngressFillPipeAsync(_socket, _ingressPipe.Writer, _cts.Token);
+        Reader = _ingressPipe.Reader;
+
+        // Data flow from the pipe to the socket
+        _egressPipe = PipePool.Shared.Get();
+        _egressFillTask = EgressFillSocketAsync(_socket, _egressPipe.Reader, _cts.Token);
+        Writer = _egressPipe.Writer;
+
+        PeerInfo = GetPeerInfo(socket);
+        ConnectionTimestamp = DateTimeOffset.UtcNow;
+    }
+
+    public void SetInfoHash(InfoHash infoHash)
+    {
+        if (InfoHash != InfoHash.None)
+            throw new InvalidOperationException("InfoHash already set");
+
+        InfoHash = infoHash;
+    }
+
+    public void SetPeerId(PeerId peerId)
+    {
+        PeerId = peerId;
+    }
+
+    private async Task IngressFillPipeAsync(Socket socket, PipeWriter writer, CancellationToken stoppingToken)
+    {
+        const int minimumBufferSize = 512;
+
+        while (!stoppingToken.IsCancellationRequested)
+        {
+            try
+            {
+                Memory<byte> memory = writer.GetMemory(minimumBufferSize);
+                int bytesRead = await socket.ReceiveAsync(memory, SocketFlags.None, stoppingToken);
+                _onIngressBytes?.Invoke(InfoHash, bytesRead);
+                if (bytesRead == 0)
+                {
+                    break;
+                }
+
+                writer.Advance(bytesRead);
+                FlushResult result = await writer.FlushAsync(stoppingToken);
+
+                if (result.IsCompleted)
+                {
+                    break;
+                }
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Error reading from peer");
+                break;
+            }
+        }
+
+        writer.Complete();
+    }
+
+    private async Task EgressFillSocketAsync(Socket socket, PipeReader reader, CancellationToken stoppingToken)
+    {
+        while (!stoppingToken.IsCancellationRequested)
+        {
+            try
+            {
+                ReadResult result = await reader.ReadAsync(stoppingToken);
+                var buffer = result.Buffer;
+
+                foreach (var block in buffer)
+                {
+                    var bytesWritten = await socket.SendAsync(block, SocketFlags.None, stoppingToken);
+                    _onEgressBytes?.Invoke(InfoHash, bytesWritten);
+                }
+
+                reader.AdvanceTo(buffer.End);
+
+                if (result.IsCompleted)
+                {
+                    break;
+                }
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Error writing to peer");
+                break;
+            }
+        }
+
+        reader.Complete();
+    }
+
+    private static PeerInfo GetPeerInfo(Socket socket)
+    {
+        var ipEndPoint = (IPEndPoint)socket.RemoteEndPoint!;
+        return new PeerInfo(ipEndPoint.Address, ipEndPoint.Port);
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        _cts.Cancel();
+        await Task.WhenAll(_ingressFillTask, _egressFillTask);
+        _egressPipe.Reader.Complete();
+        _egressPipe.Writer.Complete();
+        _ingressPipe.Reader.Complete();
+        _ingressPipe.Writer.Complete();
+
+        PipePool.Shared.Return(_ingressPipe);
+        PipePool.Shared.Return(_egressPipe);
+
+        _socket.Dispose();
+        _logger.LogDebug("Disposing connection {Id}", Id);
+    }
+}

--- a/src/Torrential.Core/PeerWireState.cs
+++ b/src/Torrential.Core/PeerWireState.cs
@@ -1,0 +1,12 @@
+namespace Torrential.Core;
+
+public sealed class PeerWireState
+{
+    public DateTimeOffset LastChokedAt { get; set; } = DateTimeOffset.UtcNow;
+    public bool AmChoked { get; set; } = true;
+    public bool PeerChoked { get; set; } = true;
+    public bool AmInterested { get; set; } = false;
+    public bool PeerInterested { get; set; } = false;
+    public Bitfield? PeerBitfield { get; set; } = null;
+    public DateTimeOffset PeerLastInterestedAt { get; set; } = DateTimeOffset.UtcNow;
+}

--- a/src/Torrential.Core/PieceRequestMessage.cs
+++ b/src/Torrential.Core/PieceRequestMessage.cs
@@ -1,0 +1,19 @@
+using System.Buffers;
+
+namespace Torrential.Core;
+
+public readonly record struct PieceRequestMessage(int PieceIndex, int Begin, int Length)
+{
+    public static PieceRequestMessage FromReadOnlySequence(ReadOnlySequence<byte> payload)
+    {
+        var reader = new SequenceReader<byte>(payload);
+        if (!reader.TryReadBigEndian(out int pieceIndex))
+            throw new InvalidDataException("Could not read piece index");
+        if (!reader.TryReadBigEndian(out int begin))
+            throw new InvalidDataException("Could not read begin index");
+        if (!reader.TryReadBigEndian(out int length))
+            throw new InvalidDataException("Could not read length");
+
+        return new PieceRequestMessage(pieceIndex, begin, length);
+    }
+}

--- a/src/Torrential.Core/PipePool.cs
+++ b/src/Torrential.Core/PipePool.cs
@@ -1,0 +1,23 @@
+using Microsoft.Extensions.ObjectPool;
+using System.IO.Pipelines;
+
+namespace Torrential.Core;
+
+public static class PipePool
+{
+    public readonly static ObjectPool<Pipe> Shared = new DefaultObjectPool<Pipe>(new PipePoolPolicy());
+}
+
+internal sealed class PipePoolPolicy : PooledObjectPolicy<Pipe>
+{
+    public override Pipe Create()
+    {
+        return new Pipe();
+    }
+
+    public override bool Return(Pipe obj)
+    {
+        obj.Reset();
+        return true;
+    }
+}

--- a/src/Torrential.Core/PooledBlock.cs
+++ b/src/Torrential.Core/PooledBlock.cs
@@ -1,0 +1,51 @@
+using System.Buffers;
+
+namespace Torrential.Core;
+
+public sealed class PooledBlock : IDisposable
+{
+    private readonly ArrayPool<byte> _pool;
+    private readonly int _size;
+    private readonly byte[] _buffer;
+    public ReadOnlySpan<byte> Buffer => _buffer.AsSpan().Slice(0, _size);
+
+    public InfoHash InfoHash { get; private set; }
+    public int PieceIndex { get; private set; }
+    public int Offset { get; private set; }
+
+    public static PooledBlock FromReadOnlySequence(ReadOnlySequence<byte> sequence, int chunkSize, InfoHash infoHash)
+    {
+        var reader = new SequenceReader<byte>(sequence);
+
+        if (!reader.TryReadBigEndian(out int pieceIndex))
+            throw new ArgumentException("Error reading block pieceIndex");
+        if (!reader.TryReadBigEndian(out int pieceOffset))
+            throw new ArgumentException("Error reading block offset");
+        if (!reader.TryReadExact(chunkSize, out var blockSequence))
+            throw new ArgumentException("Error reading piece block data");
+
+        var block = new PooledBlock((int)blockSequence.Length, ArrayPool<byte>.Shared, infoHash, pieceIndex, pieceOffset);
+        blockSequence.CopyTo(block._buffer);
+        return block;
+    }
+
+    private PooledBlock(int size, ArrayPool<byte> pool, InfoHash infoHash, int index, int offset)
+    {
+        InfoHash = infoHash;
+        PieceIndex = index;
+        Offset = offset;
+        _pool = pool;
+        _size = size;
+        _buffer = _pool.Rent(size);
+    }
+
+    public void Fill(ref ReadOnlySequence<byte> sequence)
+    {
+        sequence.CopyTo(_buffer);
+    }
+
+    public void Dispose()
+    {
+        _pool.Return(_buffer);
+    }
+}

--- a/src/Torrential.Core/PreparedPacket.cs
+++ b/src/Torrential.Core/PreparedPacket.cs
@@ -1,0 +1,24 @@
+using System.Buffers;
+
+namespace Torrential.Core;
+
+public sealed class PreparedPacket : IDisposable
+{
+    private readonly ArrayPool<byte> _pool;
+    private readonly byte[] _buffer;
+    public readonly int Size;
+
+    public PreparedPacket(int size)
+    {
+        _pool = ArrayPool<byte>.Shared;
+        _buffer = _pool.Rent(size);
+        Size = size;
+    }
+
+    public void Dispose()
+    {
+        _pool.Return(_buffer);
+    }
+
+    public Span<byte> AsSpan() => _buffer.AsSpan()[..Size];
+}

--- a/src/Torrential.Core/SequenceReaderExtensions.cs
+++ b/src/Torrential.Core/SequenceReaderExtensions.cs
@@ -1,0 +1,45 @@
+using System.Buffers;
+
+namespace Torrential.Core;
+
+public static class SequenceReaderExtensions
+{
+    public static bool TryReadInfoHash(this ref SequenceReader<byte> reader, out InfoHash hash)
+    {
+        hash = InfoHash.None;
+        if (!reader.TryReadExact(20, out var infoHashSequence))
+            return false;
+
+        var internalSr = new SequenceReader<byte>(infoHashSequence);
+        if (!internalSr.TryReadBigEndian(out long p1)) return false;
+        if (!internalSr.TryReadBigEndian(out long p2)) return false;
+        if (!internalSr.TryReadBigEndian(out int p3)) return false;
+        hash = new InfoHash(p1, p2, p3);
+        return true;
+    }
+
+    public static bool TryReadPeerId(this ref SequenceReader<byte> reader, out PeerId peerId)
+    {
+        peerId = PeerId.None;
+        if (!reader.TryReadExact(20, out var peerIdSequence))
+            return false;
+
+        var internalSr = new SequenceReader<byte>(peerIdSequence);
+        if (!internalSr.TryReadBigEndian(out long p1)) return false;
+        if (!internalSr.TryReadBigEndian(out long p2)) return false;
+        if (!internalSr.TryReadBigEndian(out int p3)) return false;
+        peerId = new PeerId(p1, p2, p3);
+        return true;
+    }
+
+    public static bool TryReadPeerExtensions(this ref SequenceReader<byte> reader, out PeerExtensions extensions)
+    {
+        extensions = PeerExtensions.None;
+
+        if (!reader.TryReadBigEndian(out long extensionsLong))
+            return false;
+
+        extensions = PeerExtensions.FromLong(extensionsLong);
+        return true;
+    }
+}

--- a/src/Torrential.Core/Torrential.Core.csproj
+++ b/src/Torrential.Core/Torrential.Core.csproj
@@ -9,6 +9,11 @@
   <ItemGroup>
     <PackageReference Include="System.IO.Pipelines" Version="8.0.0" />
     <PackageReference Include="Microsoft.Extensions.ObjectPool" Version="8.0.4" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <InternalsVisibleTo Include="Torrential.Core.Tests" />
   </ItemGroup>
 
 </Project>

--- a/src/Torrential.Core/Torrential.Core.csproj
+++ b/src/Torrential.Core/Torrential.Core.csproj
@@ -1,0 +1,14 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="System.IO.Pipelines" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.ObjectPool" Version="8.0.4" />
+  </ItemGroup>
+
+</Project>

--- a/src/Torrential.Harness/Program.cs
+++ b/src/Torrential.Harness/Program.cs
@@ -1,0 +1,241 @@
+using System.Net.Sockets;
+using Microsoft.Extensions.Logging;
+using Torrential.Core;
+using Torrential.Harness;
+
+using var loggerFactory = LoggerFactory.Create(builder =>
+{
+    builder.AddConsole();
+    builder.SetMinimumLevel(LogLevel.Information);
+});
+var logger = loggerFactory.CreateLogger("Harness");
+
+if (args.Length == 0)
+{
+    Console.WriteLine("Usage: Torrential.Harness <path-to-torrent-file>");
+    return 1;
+}
+
+var torrentPath = args[0];
+if (!File.Exists(torrentPath))
+{
+    Console.WriteLine($"File not found: {torrentPath}");
+    return 1;
+}
+
+// 1. Parse torrent file
+TorrentInfo torrent;
+try
+{
+    torrent = TorrentFileParser.FromFile(torrentPath);
+}
+catch (Exception ex)
+{
+    Console.WriteLine($"Failed to parse torrent file: {ex.Message}");
+    return 1;
+}
+
+var sizeMB = torrent.TotalSize / (1024.0 * 1024.0);
+var sizeDisplay = sizeMB >= 1024
+    ? $"{sizeMB / 1024.0:F1} GB"
+    : $"{sizeMB:F0} MB";
+
+logger.LogInformation("Parsed torrent: {Name} ({Size}, {Pieces} pieces, piece size {PieceSize})",
+    torrent.Name, sizeDisplay, torrent.NumberOfPieces, torrent.PieceSize);
+
+if (torrent.AnnounceUrls.Count == 0)
+{
+    Console.WriteLine("No HTTP trackers found in torrent file.");
+    return 1;
+}
+
+// 2. Announce to tracker to get peers
+var selfId = PeerId.New;
+logger.LogInformation("Our peer ID: {PeerId}", selfId.ToAsciiString());
+
+using var httpClient = new HttpClient { Timeout = TimeSpan.FromSeconds(15) };
+var trackerClient = new SimpleTrackerClient(httpClient, loggerFactory.CreateLogger("Tracker"));
+
+List<TrackerPeer> peers = [];
+foreach (var announceUrl in torrent.AnnounceUrls)
+{
+    peers = await trackerClient.Announce(announceUrl, torrent.InfoHash, selfId, torrent.TotalSize);
+    if (peers.Count > 0)
+    {
+        logger.LogInformation("Got {Count} peers from tracker", peers.Count);
+        break;
+    }
+}
+
+if (peers.Count == 0)
+{
+    Console.WriteLine("No peers found from any tracker.");
+    return 1;
+}
+
+// 3. Try to connect to peers
+using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(60));
+var handshakeLogger = loggerFactory.CreateLogger<HandshakeService>();
+var handshakeService = new HandshakeService(handshakeLogger);
+var connLogger = loggerFactory.CreateLogger("Connection");
+
+PeerWireSocketConnection? activeConnection = null;
+HandshakeResponse handshakeResult = default;
+
+foreach (var peer in peers)
+{
+    if (cts.IsCancellationRequested) break;
+
+    logger.LogInformation("Connecting to {Ip}:{Port}...", peer.Ip, peer.Port);
+
+    Socket? socket = null;
+    try
+    {
+        socket = new Socket(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp);
+        using var connectCts = CancellationTokenSource.CreateLinkedTokenSource(cts.Token);
+        connectCts.CancelAfter(TimeSpan.FromSeconds(5));
+        await socket.ConnectAsync(peer.Ip, peer.Port, connectCts.Token);
+
+        var connection = new PeerWireSocketConnection(socket, connLogger);
+        connection.SetInfoHash(torrent.InfoHash);
+
+        // Perform outbound handshake
+        using var handshakeCts = CancellationTokenSource.CreateLinkedTokenSource(cts.Token);
+        handshakeCts.CancelAfter(TimeSpan.FromSeconds(10));
+
+        handshakeResult = await handshakeService.HandleOutbound(
+            connection.Writer,
+            connection.Reader,
+            torrent.InfoHash,
+            selfId,
+            handshakeCts.Token);
+
+        if (!handshakeResult.Success)
+        {
+            logger.LogWarning("Handshake failed with {Ip}:{Port} - {Error}", peer.Ip, peer.Port, handshakeResult.Error);
+            await connection.DisposeAsync();
+            continue;
+        }
+
+        connection.SetPeerId(handshakeResult.PeerId);
+        activeConnection = connection;
+        logger.LogInformation("Handshake successful with peer {PeerId}", handshakeResult.PeerId.ToAsciiString());
+        break;
+    }
+    catch (Exception ex)
+    {
+        logger.LogWarning("Failed to connect to {Ip}:{Port}: {Error}", peer.Ip, peer.Port, ex.Message);
+        socket?.Dispose();
+    }
+}
+
+if (activeConnection == null)
+{
+    Console.WriteLine("Could not connect to any peer.");
+    return 1;
+}
+
+// 4. Start protocol message processing
+await using var connection2 = activeConnection;
+var clientLogger = loggerFactory.CreateLogger("PeerWire");
+var client = new PeerWireClient(activeConnection, torrent.NumberOfPieces, clientLogger, cts.Token);
+var processTask = client.ProcessMessages();
+
+// 5. Send our empty bitfield (we have nothing)
+using (var emptyBitfield = new Bitfield(torrent.NumberOfPieces))
+{
+    await client.SendBitfield(emptyBitfield);
+    logger.LogInformation("Sent empty bitfield");
+}
+
+// 6. Wait for peer's bitfield and unchoke
+var waitStart = DateTime.UtcNow;
+while (client.State.PeerBitfield == null || client.State.PeerBitfield.HasNone())
+{
+    if (DateTime.UtcNow - waitStart > TimeSpan.FromSeconds(10))
+    {
+        logger.LogWarning("Timed out waiting for peer bitfield");
+        break;
+    }
+    await Task.Delay(100, cts.Token);
+}
+
+if (client.State.PeerBitfield != null)
+{
+    logger.LogInformation("Received peer bitfield: {Completion:F1}% complete",
+        client.State.PeerBitfield.CompletionRatio * 100);
+}
+
+// 7. Send Interested
+await client.SendInterested();
+logger.LogInformation("Sent Interested");
+
+// 8. Wait for Unchoke
+waitStart = DateTime.UtcNow;
+while (client.State.AmChoked)
+{
+    if (DateTime.UtcNow - waitStart > TimeSpan.FromSeconds(15))
+    {
+        logger.LogWarning("Timed out waiting for Unchoke");
+        await client.DisposeAsync();
+        return 1;
+    }
+    await Task.Delay(100, cts.Token);
+}
+logger.LogInformation("Received Unchoke");
+
+// 9. Request piece 0 block by block
+const int blockSize = 16384;
+var pieceSize = torrent.PieceSize;
+// Last piece might be smaller
+var requestPieceSize = torrent.NumberOfPieces == 1
+    ? torrent.TotalSize
+    : pieceSize;
+var numBlocks = (int)((requestPieceSize + blockSize - 1) / blockSize);
+var lastBlockSize = (int)(requestPieceSize - (long)(numBlocks - 1) * blockSize);
+
+logger.LogInformation("Requesting piece 0 ({PieceSize} bytes, {NumBlocks} blocks)", requestPieceSize, numBlocks);
+
+for (int i = 0; i < numBlocks; i++)
+{
+    var offset = i * blockSize;
+    var length = (i == numBlocks - 1) ? lastBlockSize : blockSize;
+    await client.SendPieceRequest(pieceIndex: 0, begin: offset, length: length);
+}
+
+// 10. Read blocks and log them
+var receivedBlocks = 0;
+var pieceTimeout = CancellationTokenSource.CreateLinkedTokenSource(cts.Token);
+pieceTimeout.CancelAfter(TimeSpan.FromSeconds(30));
+
+try
+{
+    await foreach (var block in client.InboundBlocks.ReadAllAsync(pieceTimeout.Token))
+    {
+        using (block)
+        {
+            logger.LogInformation("Received block: piece={PieceIndex} offset={Offset} size={Size}",
+                block.PieceIndex, block.Offset, block.Buffer.Length);
+            receivedBlocks++;
+
+            if (receivedBlocks >= numBlocks)
+                break;
+        }
+    }
+}
+catch (OperationCanceledException)
+{
+    logger.LogWarning("Timed out waiting for blocks ({Received}/{Expected})", receivedBlocks, numBlocks);
+}
+
+if (receivedBlocks >= numBlocks)
+{
+    logger.LogInformation("Piece 0 fully received (discarded). Disconnecting.");
+}
+else
+{
+    logger.LogInformation("Received {Received}/{Expected} blocks. Disconnecting.", receivedBlocks, numBlocks);
+}
+
+await client.DisposeAsync();
+return 0;

--- a/src/Torrential.Harness/SimpleTrackerClient.cs
+++ b/src/Torrential.Harness/SimpleTrackerClient.cs
@@ -1,0 +1,102 @@
+using System.Buffers.Binary;
+using System.Net;
+using System.Web;
+using BencodeNET.Objects;
+using BencodeNET.Parsing;
+using Microsoft.Extensions.Logging;
+using Torrential.Core;
+
+namespace Torrential.Harness;
+
+public record TrackerPeer(IPAddress Ip, int Port);
+
+public class SimpleTrackerClient
+{
+    private readonly HttpClient _client;
+    private readonly ILogger _logger;
+
+    public SimpleTrackerClient(HttpClient client, ILogger logger)
+    {
+        _client = client;
+        _logger = logger;
+    }
+
+    public async Task<List<TrackerPeer>> Announce(
+        string announceUrl,
+        InfoHash infoHash,
+        PeerId peerId,
+        long totalSize)
+    {
+        var urlEncodedHash = string.Create(60, infoHash, (span, hash) =>
+        {
+            hash.WriteUrlEncodedHash(span);
+        });
+        var urlEncodedPeerId = HttpUtility.UrlEncode(peerId.ToAsciiString());
+
+        var url = $"{announceUrl}?info_hash={urlEncodedHash}&port=6881&peer_id={urlEncodedPeerId}&numwant=50&no_peer_id=1&compact=1&downloaded=0&uploaded=0&left={totalSize}";
+
+        _logger.LogInformation("Announcing to tracker: {Url}", announceUrl);
+
+        try
+        {
+            using var response = await _client.GetAsync(url);
+            var parser = new BencodeParser();
+            var dict = parser.Parse<BDictionary>(await response.Content.ReadAsStreamAsync());
+
+            if (!dict.TryGetValue("peers", out var bPeers))
+            {
+                _logger.LogWarning("Tracker response did not contain peers");
+                return [];
+            }
+
+            return ParsePeers(bPeers);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Tracker announce failed for {Url}", announceUrl);
+            return [];
+        }
+    }
+
+    private static List<TrackerPeer> ParsePeers(IBObject bPeers)
+    {
+        if (bPeers is BString bPeerString)
+            return ParseCompactPeers(bPeerString);
+
+        if (bPeers is BList bPeerList)
+            return ParseDictPeers(bPeerList);
+
+        return [];
+    }
+
+    private static List<TrackerPeer> ParseCompactPeers(BString bPeersString)
+    {
+        var numPeers = bPeersString.Length / 6;
+        var peers = new List<TrackerPeer>(numPeers);
+        var data = bPeersString.Value.Span;
+
+        for (int i = 0; i < numPeers; i++)
+        {
+            var ip = new IPAddress(data.Slice(i * 6, 4));
+            var port = BinaryPrimitives.ReadUInt16BigEndian(data.Slice(i * 6 + 4, 2));
+            peers.Add(new TrackerPeer(ip, port));
+        }
+
+        return peers;
+    }
+
+    private static List<TrackerPeer> ParseDictPeers(BList bPeersList)
+    {
+        var peers = new List<TrackerPeer>(bPeersList.Count);
+        for (int i = 0; i < bPeersList.Count; i++)
+        {
+            if (bPeersList[i] is BDictionary peer)
+            {
+                var ip = new IPAddress(peer.Get<BString>("ip").Value.Span);
+                var port = (int)peer.Get<BNumber>("port").Value;
+                peers.Add(new TrackerPeer(ip, port));
+            }
+        }
+        return peers;
+    }
+}

--- a/src/Torrential.Harness/TorrentFileParser.cs
+++ b/src/Torrential.Harness/TorrentFileParser.cs
@@ -1,0 +1,40 @@
+using BencodeNET.Parsing;
+using BencodeNET.Torrents;
+using Torrential.Core;
+
+namespace Torrential.Harness;
+
+public record TorrentInfo(
+    string Name,
+    InfoHash InfoHash,
+    long PieceSize,
+    int NumberOfPieces,
+    long TotalSize,
+    IReadOnlyList<string> AnnounceUrls);
+
+public static class TorrentFileParser
+{
+    public static TorrentInfo FromFile(string fileName)
+    {
+        using var fs = File.OpenRead(fileName);
+        var parser = new BencodeParser();
+        var torrent = parser.Parse<Torrent>(fs);
+
+        var announceUrls = torrent.Trackers
+            .SelectMany(x => x)
+            .Where(x => x.StartsWith("http://") || x.StartsWith("https://"))
+            .Where(x => !x.Contains("ipv6"))
+            .ToList();
+
+        var infoHash = InfoHash.FromSpan(torrent.OriginalInfoHashBytes);
+        var numberOfPieces = torrent.Pieces.Length / 20;
+
+        return new TorrentInfo(
+            Name: torrent.DisplayName,
+            InfoHash: infoHash,
+            PieceSize: torrent.PieceSize,
+            NumberOfPieces: numberOfPieces,
+            TotalSize: torrent.TotalSize,
+            AnnounceUrls: announceUrls);
+    }
+}

--- a/src/Torrential.Harness/Torrential.Harness.csproj
+++ b/src/Torrential.Harness/Torrential.Harness.csproj
@@ -1,0 +1,19 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Torrential.Core\Torrential.Core.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="BencodeNET" Version="5.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="8.0.0" />
+  </ItemGroup>
+
+</Project>

--- a/test/Torrential.Core.Tests/BitConverterExtensionTests.cs
+++ b/test/Torrential.Core.Tests/BitConverterExtensionTests.cs
@@ -1,0 +1,43 @@
+using Torrential.Core;
+using Xunit;
+
+namespace Torrential.Core.Tests;
+
+public class BitConverterExtensionTests
+{
+    [Fact]
+    public void Write_Int32()
+    {
+        Span<byte> buffer = stackalloc byte[4];
+        buffer.TryWriteBigEndian(40);
+        Span<byte> expected = [0x00, 0x00, 0x00, 0x28];
+        Assert.True(buffer.SequenceEqual(expected));
+    }
+
+    [Fact]
+    public void Write_Int64()
+    {
+        Span<byte> buffer = stackalloc byte[8];
+        buffer.TryWriteBigEndian(40l);
+        Span<byte> expected = [0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x28];
+        Assert.True(buffer.SequenceEqual(expected));
+    }
+
+    [Fact]
+    public void Read_Int32()
+    {
+        Span<byte> buffer = [0x00, 0x00, 0x00, 0x28];
+        var expected = 40;
+        Assert.Equal(buffer.ReadBigEndianInt32(), expected);
+        Assert.True(buffer.SequenceEqual(new byte[] { 0x00, 0x00, 0x00, 0x28 }));
+    }
+
+    [Fact]
+    public void Read_UInt16()
+    {
+        Span<byte> buffer = [0x00, 0x28];
+        ushort expected = 40;
+        Assert.Equal(buffer.ReadBigEndianUInt16(), expected);
+        Assert.True(buffer.SequenceEqual(new byte[] { 0x00, 0x28 }));
+    }
+}

--- a/test/Torrential.Core.Tests/BitfieldTests.cs
+++ b/test/Torrential.Core.Tests/BitfieldTests.cs
@@ -1,0 +1,71 @@
+using Torrential.Core;
+using Xunit;
+
+namespace Torrential.Core.Tests;
+
+public class BitfieldTests
+{
+    [Fact]
+    public void Has_all_with_partial_final_byte()
+    {
+        var myBitfield = new Bitfield(2516);
+        var peerBitfieldData = new byte[315];
+        Array.Fill(peerBitfieldData, (byte)255);
+
+        var peerBitfield = new Bitfield(peerBitfieldData);
+
+        //Stage my bitfield to have all but the final byte set
+        var myPeerBitfieldData = new byte[314];
+        Array.Fill(myPeerBitfieldData, (byte)255);
+        myBitfield.Fill(myPeerBitfieldData);
+
+        Assert.False(myBitfield.HasAll());
+        var suggestedPiece = myBitfield.SuggestPieceToDownload(peerBitfield);
+        Assert.NotNull(suggestedPiece.Index);
+
+        myBitfield.MarkHave(2512);
+        Assert.False(myBitfield.HasAll());
+
+        myBitfield.MarkHave(2513);
+        Assert.False(myBitfield.HasAll());
+
+        myBitfield.MarkHave(2514);
+        Assert.False(myBitfield.HasAll());
+
+        myBitfield.MarkHave(2515);
+        Assert.True(myBitfield.HasAll());
+        Assert.Equal(1.0, myBitfield.CompletionRatio, 0);
+
+        //We should no longer be suggesting pieces if we have the all
+        Assert.Null(myBitfield.SuggestPieceToDownload(peerBitfield).Index);
+    }
+
+    [Fact]
+    public void Has_all_with_partial_final_byte_alt()
+    {
+        var myBitfield = new Bitfield(2106);
+        var peerBitfieldData = new byte[264];
+        Array.Fill(peerBitfieldData, (byte)255);
+
+        var peerBitfield = new Bitfield(peerBitfieldData);
+
+        //Stage my bitfield to have all but the final byte set
+        var myPeerBitfieldData = new byte[263];
+        Array.Fill(myPeerBitfieldData, (byte)255);
+        myBitfield.Fill(myPeerBitfieldData);
+
+        Assert.False(myBitfield.HasAll());
+        var suggestedPiece = myBitfield.SuggestPieceToDownload(peerBitfield);
+        Assert.NotNull(suggestedPiece.Index);
+
+        myBitfield.MarkHave(2104);
+        Assert.False(myBitfield.HasAll());
+
+        myBitfield.MarkHave(2105);
+        Assert.True(myBitfield.HasAll());
+        Assert.Equal(1.0, myBitfield.CompletionRatio, 0);
+
+        //We should no longer be suggesting pieces if we have the all
+        Assert.Null(myBitfield.SuggestPieceToDownload(peerBitfield).Index);
+    }
+}

--- a/test/Torrential.Core.Tests/HandshakeTests.cs
+++ b/test/Torrential.Core.Tests/HandshakeTests.cs
@@ -1,0 +1,194 @@
+using System.Buffers;
+using System.IO.Pipelines;
+using Microsoft.Extensions.Logging.Abstractions;
+using Xunit;
+
+namespace Torrential.Core.Tests;
+
+public class HandshakeTests
+{
+    private static readonly byte[] ProtocolBytes = "BitTorrent protocol"u8.ToArray();
+
+    private static InfoHash CreateTestInfoHash()
+    {
+        return InfoHash.FromHexString("0102030405060708091011121314151617181920");
+    }
+
+    [Fact]
+    public void WriteHandshake_Produces68Bytes_WithCorrectProtocolString()
+    {
+        var pipe = new Pipe();
+        var infoHash = CreateTestInfoHash();
+        var selfId = PeerId.New;
+
+        HandshakeService.WriteHandshake(pipe.Writer, infoHash, selfId);
+        pipe.Writer.FlushAsync().GetAwaiter().GetResult();
+        pipe.Writer.Complete();
+
+        var result = pipe.Reader.ReadAsync().GetAwaiter().GetResult();
+        var buffer = result.Buffer;
+
+        // Handshake must be exactly 68 bytes
+        Assert.Equal(68, buffer.Length);
+
+        // First byte is the protocol string length (19)
+        Span<byte> data = stackalloc byte[68];
+        buffer.CopyTo(data);
+        Assert.Equal(19, data[0]);
+
+        // Bytes 1-19 are the protocol identifier
+        Assert.True(data[1..20].SequenceEqual(ProtocolBytes));
+
+        // Bytes 28-47 should match the info hash
+        Span<byte> expectedHash = stackalloc byte[20];
+        infoHash.CopyTo(expectedHash);
+        Assert.True(data[28..48].SequenceEqual(expectedHash));
+
+        // Bytes 48-67 should match the peer id
+        Span<byte> expectedPeerId = stackalloc byte[20];
+        selfId.CopyTo(expectedPeerId);
+        Assert.True(data[48..68].SequenceEqual(expectedPeerId));
+
+        pipe.Reader.Complete();
+    }
+
+    [Fact]
+    public void ParseHandshake_ValidHandshake_ReturnsSuccess()
+    {
+        var infoHash = CreateTestInfoHash();
+        var peerId = PeerId.New;
+
+        // Build a valid 68-byte handshake
+        var handshake = new byte[68];
+        handshake[0] = 19;
+        ProtocolBytes.CopyTo(handshake.AsSpan(1));
+        // Reserved bytes 20-27 are zero (already default)
+        Span<byte> hashBytes = stackalloc byte[20];
+        infoHash.CopyTo(hashBytes);
+        hashBytes.CopyTo(handshake.AsSpan(28));
+        Span<byte> peerIdBytes = stackalloc byte[20];
+        peerId.CopyTo(peerIdBytes);
+        peerIdBytes.CopyTo(handshake.AsSpan(48));
+
+        var sequence = new ReadOnlySequence<byte>(handshake);
+        var response = HandshakeService.ParseHandshake(ref sequence);
+
+        Assert.True(response.Success);
+        Assert.Equal(HandshakeError.NONE, response.Error);
+        Assert.Equal(infoHash, response.InfoHash);
+        Assert.Equal(peerId, response.PeerId);
+    }
+
+    [Fact]
+    public void ParseHandshake_InvalidProtocolIdentifier_ReturnsError()
+    {
+        var handshake = new byte[68];
+        handshake[0] = 19;
+        // Write garbage instead of "BitTorrent protocol"
+        "INVALID protocol xx"u8.CopyTo(handshake.AsSpan(1));
+        // Rest can be zeroes
+
+        var sequence = new ReadOnlySequence<byte>(handshake);
+        var response = HandshakeService.ParseHandshake(ref sequence);
+
+        Assert.False(response.Success);
+        Assert.Equal(HandshakeError.INVALID_PROTOCOL, response.Error);
+    }
+
+    [Fact]
+    public async Task HandleOutbound_SendsHandshakeAndParsesResponse()
+    {
+        var service = new HandshakeService(NullLogger<HandshakeService>.Instance);
+        var infoHash = CreateTestInfoHash();
+        var selfId = PeerId.New;
+        var remotePeerId = PeerId.New;
+
+        // Outbound: we write to outPipe, peer reads from it
+        // Peer writes to inPipe, we read from it
+        var outPipe = new Pipe();
+        var inPipe = new Pipe();
+
+        // Simulate the remote peer's response by writing a valid handshake to inPipe
+        var remoteHandshake = new byte[68];
+        remoteHandshake[0] = 19;
+        ProtocolBytes.CopyTo(remoteHandshake.AsSpan(1));
+        infoHash.CopyTo(remoteHandshake.AsSpan(28));
+        remotePeerId.CopyTo(remoteHandshake.AsSpan(48));
+
+        await inPipe.Writer.WriteAsync(remoteHandshake);
+        inPipe.Writer.Complete();
+
+        var response = await service.HandleOutbound(outPipe.Writer, inPipe.Reader, infoHash, selfId, CancellationToken.None);
+
+        Assert.True(response.Success);
+        Assert.Equal(infoHash, response.InfoHash);
+        Assert.Equal(remotePeerId, response.PeerId);
+
+        outPipe.Writer.Complete();
+        outPipe.Reader.Complete();
+        inPipe.Reader.Complete();
+    }
+
+    [Fact]
+    public async Task HandleInbound_ValidHashCallback_SendsResponseAndReturnsSuccess()
+    {
+        var service = new HandshakeService(NullLogger<HandshakeService>.Instance);
+        var infoHash = CreateTestInfoHash();
+        var selfId = PeerId.New;
+        var remotePeerId = PeerId.New;
+
+        var inPipe = new Pipe();
+        var outPipe = new Pipe();
+
+        // Simulate remote peer sending a handshake
+        var remoteHandshake = new byte[68];
+        remoteHandshake[0] = 19;
+        ProtocolBytes.CopyTo(remoteHandshake.AsSpan(1));
+        infoHash.CopyTo(remoteHandshake.AsSpan(28));
+        remotePeerId.CopyTo(remoteHandshake.AsSpan(48));
+
+        await inPipe.Writer.WriteAsync(remoteHandshake);
+        inPipe.Writer.Complete();
+
+        var response = await service.HandleInbound(outPipe.Writer, inPipe.Reader, selfId, hash => hash == infoHash, CancellationToken.None);
+
+        Assert.True(response.Success);
+        Assert.Equal(infoHash, response.InfoHash);
+        Assert.Equal(remotePeerId, response.PeerId);
+
+        outPipe.Writer.Complete();
+        outPipe.Reader.Complete();
+        inPipe.Reader.Complete();
+    }
+
+    [Fact]
+    public async Task HandleInbound_InvalidHashCallback_ReturnsInvalidHashError()
+    {
+        var service = new HandshakeService(NullLogger<HandshakeService>.Instance);
+        var infoHash = CreateTestInfoHash();
+        var selfId = PeerId.New;
+        var remotePeerId = PeerId.New;
+
+        var inPipe = new Pipe();
+        var outPipe = new Pipe();
+
+        var remoteHandshake = new byte[68];
+        remoteHandshake[0] = 19;
+        ProtocolBytes.CopyTo(remoteHandshake.AsSpan(1));
+        infoHash.CopyTo(remoteHandshake.AsSpan(28));
+        remotePeerId.CopyTo(remoteHandshake.AsSpan(48));
+
+        await inPipe.Writer.WriteAsync(remoteHandshake);
+        inPipe.Writer.Complete();
+
+        // Callback always returns false — hash not recognized
+        var response = await service.HandleInbound(outPipe.Writer, inPipe.Reader, selfId, _ => false, CancellationToken.None);
+
+        Assert.False(response.Success);
+        Assert.Equal(HandshakeError.INVALID_HASH, response.Error);
+
+        outPipe.Writer.Complete();
+        outPipe.Reader.Complete();
+        inPipe.Reader.Complete();
+    }
+}

--- a/test/Torrential.Core.Tests/MessagePackerTests.cs
+++ b/test/Torrential.Core.Tests/MessagePackerTests.cs
@@ -1,0 +1,152 @@
+using System.Buffers;
+using Torrential.Core;
+using Xunit;
+
+namespace Torrential.Core.Tests;
+
+public class MessagePackerTests
+{
+    [Fact]
+    public void Pack_MessageId()
+    {
+        using var pak = MessagePacker.Pack(1);
+        var span = pak.AsSpan();
+        Assert.Equal(5, span.Length);
+        Assert.Equal(1, span[4]);
+    }
+
+    [Fact]
+    public void Pack_MessageId_P1()
+    {
+        using var pak = MessagePacker.Pack(1, 2);
+        var span = pak.AsSpan();
+        Assert.Equal(9, span.Length);
+        Assert.Equal(1, span[4]);
+        Assert.Equal(2, span.Slice(5).ReadBigEndianInt32());
+    }
+
+    [Fact]
+    public void Pack_MessageId_P1_P2()
+    {
+        using var pak = MessagePacker.Pack(1, 2, 3);
+        var span = pak.AsSpan();
+        Assert.Equal(13, span.Length);
+        Assert.Equal(1, span[4]);
+        Assert.Equal(2, span.Slice(5).ReadBigEndianInt32());
+        Assert.Equal(3, span.Slice(9).ReadBigEndianInt32());
+    }
+
+    [Fact]
+    public void Pack_MessageId_P1_P2_P3()
+    {
+        using var pak = MessagePacker.Pack(1, 2, 3, 4);
+        var span = pak.AsSpan();
+        Assert.Equal(17, span.Length);
+        Assert.Equal(1, span[4]);
+        Assert.Equal(2, span.Slice(5).ReadBigEndianInt32());
+        Assert.Equal(3, span.Slice(9).ReadBigEndianInt32());
+        Assert.Equal(4, span.Slice(13).ReadBigEndianInt32());
+    }
+
+    [Fact]
+    public void Pack_PieceData()
+    {
+        var data = new byte[] { 1, 2, 3, 4, 5 };
+        using var pak = MessagePacker.Pack(1, 2, data);
+        var span = pak.AsSpan();
+        Assert.Equal(13 + data.Length, span.Length);
+        Assert.Equal(PeerWireMessageType.Piece, span[4]);
+        Assert.Equal(1, span.Slice(5).ReadBigEndianInt32());
+        Assert.Equal(2, span.Slice(9).ReadBigEndianInt32());
+        Assert.Equal(data, span.Slice(13).ToArray());
+    }
+
+    [Fact]
+    public void Pack_Bitfield()
+    {
+        var bitfield = new Bitfield(20);
+        using var pak = MessagePacker.Pack(bitfield);
+        var span = pak.AsSpan();
+        Assert.Equal(5 + bitfield.Bytes.Length, span.Length);
+        Assert.Equal(PeerWireMessageType.Bitfield, span[4]);
+        Assert.True(bitfield.Bytes.SequenceEqual(span.Slice(5)));
+    }
+
+    [Fact]
+    public void Pack_PieceData_Sequence()
+    {
+        var data = new byte[] { 1, 2, 3, 4, 5 };
+        using var pak = MessagePacker.Pack(1, 2, new ReadOnlySequence<byte>(data));
+        var span = pak.AsSpan();
+        Assert.Equal(13 + data.Length, span.Length);
+        Assert.Equal(PeerWireMessageType.Piece, span[4]);
+        Assert.Equal(1, span.Slice(5).ReadBigEndianInt32());
+        Assert.Equal(2, span.Slice(9).ReadBigEndianInt32());
+        Assert.Equal(data, span.Slice(13).ToArray());
+    }
+
+    [Fact]
+    public void Pack_Bitfield_Sequence()
+    {
+        var bitfield = new Bitfield(20);
+        using var pak = MessagePacker.PackBitfield(bitfield.Bytes);
+        var span = pak.AsSpan();
+
+        Assert.Equal(8, span.Length);
+        Assert.Equal(PeerWireMessageType.Bitfield, span[4]);
+        Assert.True(bitfield.Bytes.SequenceEqual(span.Slice(5)));
+    }
+
+    [Fact]
+    public void Pack_KeepAlive()
+    {
+        // Keep-alive is 4 zero bytes (message length = 0, no message id, no payload)
+        Span<byte> keepAlive = stackalloc byte[4];
+        keepAlive.TryWriteBigEndian(0);
+
+        Assert.Equal(0, keepAlive[0]);
+        Assert.Equal(0, keepAlive[1]);
+        Assert.Equal(0, keepAlive[2]);
+        Assert.Equal(0, keepAlive[3]);
+        Assert.Equal(0, keepAlive.ReadBigEndianInt32());
+    }
+
+    [Fact]
+    public void PreparedPacket_Returns_Buffer_To_Pool_On_Dispose()
+    {
+        var pak = new PreparedPacket(10);
+        var span = pak.AsSpan();
+        Assert.Equal(10, span.Length);
+
+        // Write some data to verify the packet works
+        span[0] = 0xFF;
+        Assert.Equal(0xFF, pak.AsSpan()[0]);
+
+        // Should not throw - buffer is returned to pool
+        pak.Dispose();
+    }
+
+    [Fact]
+    public void PieceRequestMessage_FromReadOnlySequence_RoundTrip()
+    {
+        // Create a piece request: pieceIndex=5, begin=16384, length=16384
+        var pieceIndex = 5;
+        var begin = 16384;
+        var length = 16384;
+
+        // Serialize to bytes (big-endian)
+        var data = new byte[12];
+        Span<byte> dataSpan = data;
+        dataSpan.TryWriteBigEndian(pieceIndex);
+        dataSpan[4..].TryWriteBigEndian(begin);
+        dataSpan[8..].TryWriteBigEndian(length);
+
+        // Parse back
+        var sequence = new ReadOnlySequence<byte>(data);
+        var msg = PieceRequestMessage.FromReadOnlySequence(sequence);
+
+        Assert.Equal(pieceIndex, msg.PieceIndex);
+        Assert.Equal(begin, msg.Begin);
+        Assert.Equal(length, msg.Length);
+    }
+}

--- a/test/Torrential.Core.Tests/PeerWireClientTests.cs
+++ b/test/Torrential.Core.Tests/PeerWireClientTests.cs
@@ -1,0 +1,148 @@
+using System.Buffers;
+using System.IO.Pipelines;
+using Microsoft.Extensions.Logging.Abstractions;
+using Xunit;
+
+namespace Torrential.Core.Tests;
+
+internal sealed class StubPeerWireConnection : IPeerWireConnection
+{
+    private readonly Pipe _ingressPipe = new();
+    private readonly Pipe _egressPipe = new();
+
+    public Guid Id { get; } = Guid.NewGuid();
+    public PeerInfo PeerInfo { get; } = new(System.Net.IPAddress.Loopback, 6881);
+    public PeerId? PeerId { get; private set; }
+    public InfoHash InfoHash { get; private set; } = InfoHash.None;
+    public DateTimeOffset ConnectionTimestamp { get; } = DateTimeOffset.UtcNow;
+
+    /// <summary>The PipeReader that the client reads incoming data from.</summary>
+    public PipeReader Reader => _ingressPipe.Reader;
+
+    /// <summary>The PipeWriter that the client writes outgoing data to.</summary>
+    public PipeWriter Writer => _egressPipe.Writer;
+
+    /// <summary>Write bytes into the ingress pipe to simulate data arriving from the peer.</summary>
+    public PipeWriter IngressWriter => _ingressPipe.Writer;
+
+    /// <summary>Read bytes from the egress pipe to see what the client sent.</summary>
+    public PipeReader EgressReader => _egressPipe.Reader;
+
+    public void SetInfoHash(InfoHash infoHash) => InfoHash = infoHash;
+    public void SetPeerId(PeerId peerId) => PeerId = peerId;
+
+    public ValueTask DisposeAsync()
+    {
+        _ingressPipe.Reader.Complete();
+        _ingressPipe.Writer.Complete();
+        _egressPipe.Reader.Complete();
+        _egressPipe.Writer.Complete();
+        return ValueTask.CompletedTask;
+    }
+}
+
+public class PeerWireClientTests
+{
+    private static InfoHash CreateTestInfoHash() =>
+        InfoHash.FromHexString("0102030405060708091011121314151617181920");
+
+    [Fact]
+    public void Constructor_NullPeerId_Throws()
+    {
+        var conn = new StubPeerWireConnection();
+        conn.SetInfoHash(CreateTestInfoHash());
+        // PeerId is not set, so it should throw
+
+        Assert.Throws<ArgumentException>(() =>
+            new PeerWireClient(conn, 100, NullLogger.Instance, CancellationToken.None));
+    }
+
+    [Fact]
+    public void TryReadMessage_KeepAlive_ReturnsTrueWithZeroSizeAndId()
+    {
+        // Keep-alive: 4 zero bytes (message length = 0)
+        var data = new byte[] { 0, 0, 0, 0 };
+        var buffer = new ReadOnlySequence<byte>(data);
+
+        var result = PeerWireClient.TryReadMessage(ref buffer, out var messageSize, out var messageId, out var payload);
+
+        Assert.True(result);
+        Assert.Equal(0, messageSize);
+        Assert.Equal(0, messageId);
+        Assert.Equal(0, payload.Length);
+        // Buffer should be fully consumed
+        Assert.Equal(0, buffer.Length);
+    }
+
+    [Fact]
+    public void TryReadMessage_Choke_ReturnsTrueWithCorrectId()
+    {
+        // Choke: length=1, id=0
+        var data = new byte[] { 0, 0, 0, 1, 0 };
+        var buffer = new ReadOnlySequence<byte>(data);
+
+        var result = PeerWireClient.TryReadMessage(ref buffer, out var messageSize, out var messageId, out var payload);
+
+        Assert.True(result);
+        Assert.Equal(1, messageSize);
+        Assert.Equal(PeerWireMessageType.Choke, messageId);
+        Assert.Equal(0, payload.Length);
+        Assert.Equal(0, buffer.Length);
+    }
+
+    [Fact]
+    public void TryReadMessage_Have_ReturnsTrueWithPieceIndex()
+    {
+        // Have: length=5, id=4, piece index (big-endian)
+        var pieceIndex = 42;
+        var data = new byte[9];
+        // Length = 5
+        data[0] = 0; data[1] = 0; data[2] = 0; data[3] = 5;
+        // Message ID = Have (4)
+        data[4] = PeerWireMessageType.Have;
+        // Piece index = 42 (big-endian)
+        data[5] = 0; data[6] = 0; data[7] = 0; data[8] = 42;
+
+        var buffer = new ReadOnlySequence<byte>(data);
+
+        var result = PeerWireClient.TryReadMessage(ref buffer, out var messageSize, out var messageId, out var payload);
+
+        Assert.True(result);
+        Assert.Equal(5, messageSize);
+        Assert.Equal(PeerWireMessageType.Have, messageId);
+        Assert.Equal(4, payload.Length);
+
+        // Verify the piece index in the payload
+        var reader = new SequenceReader<byte>(payload);
+        Assert.True(reader.TryReadBigEndian(out int parsedIndex));
+        Assert.Equal(pieceIndex, parsedIndex);
+
+        Assert.Equal(0, buffer.Length);
+    }
+
+    [Fact]
+    public void TryReadMessage_IncompleteBuffer_ReturnsFalse()
+    {
+        // Only 3 bytes — not enough for the 4-byte length prefix
+        var data = new byte[] { 0, 0, 0 };
+        var buffer = new ReadOnlySequence<byte>(data);
+
+        var result = PeerWireClient.TryReadMessage(ref buffer, out _, out _, out _);
+
+        Assert.False(result);
+        // Buffer should be unchanged
+        Assert.Equal(3, buffer.Length);
+    }
+
+    [Fact]
+    public void TryReadMessage_IncompletePaylod_ReturnsFalse()
+    {
+        // Have message requires 9 bytes total, but we only provide 7
+        var data = new byte[] { 0, 0, 0, 5, PeerWireMessageType.Have, 0, 0 };
+        var buffer = new ReadOnlySequence<byte>(data);
+
+        var result = PeerWireClient.TryReadMessage(ref buffer, out _, out _, out _);
+
+        Assert.False(result);
+    }
+}

--- a/test/Torrential.Core.Tests/Torrential.Core.Tests.csproj
+++ b/test/Torrential.Core.Tests/Torrential.Core.Tests.csproj
@@ -1,0 +1,29 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.0" />
+    <PackageReference Include="xunit" Version="2.4.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="coverlet.collector" Version="6.0.0">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Torrential.Core\Torrential.Core.csproj" />
+  </ItemGroup>
+
+</Project>


### PR DESCRIPTION
Create a Torrential.Core class library to hold torrent protocol primitives. I want to build this app from scratch again but I want to focus on the core PeerWireProtocol first, with a heavy emphasis on reducing allocations through the use of Spans. We want to break away from mass transit completely, but we do not want to work on the full-fledged torrent app features, just low level peer wire client stuff such that we can connect to a single peer and try to download parts of a torrent (we can discard the data we receive for now, because we just want to make sure we nail the protocol). I've already implemented a lot of the protocol, but my main focus here is to keep things decoupled.

## Subtasks
- [x] **Phase 1** — Create Torrential.Core project and migrate primitives
  Create the Torrential.Core class library, add it to the solution, and migrate foundational types: InfoHash, PeerId, PeerExtensions, BitConverterExtensions, SequenceReaderExtensions, and the Bitfield types.
- [x] **Phase 1** — Implement MessagePacker and PreparedPacket with Span-based serialization
  Migrate the message packing/serialization layer to Torrential.Core with allocation-conscious Span-based APIs. Also migrate PooledBlock and PieceRequestMessage.
- [x] **Phase 2** — Build handshake service and connection abstractions
  Create the handshake protocol implementation and connection interface in Torrential.Core, decoupled from MassTransit and application-level services.
- [x] **Phase 3** — Implement PeerWireClient message processing loop
  Migrate the PeerWireClient to Torrential.Core, decoupled from MassTransit, file services, and application concerns. Focus on the protocol message processing loop.
- [x] **Phase 4** — Create minimal peer download console harness
  Build a minimal console app that can connect to a single peer, perform a handshake, and attempt to download pieces from a torrent file, discarding the received data.

**Total cost:** $0.0000
