### PR TITLE
feat: Add tracker clients

### DIFF
--- a/src/Torrential.Core/Torrential.Core.csproj
+++ b/src/Torrential.Core/Torrential.Core.csproj
@@ -7,6 +7,8 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="BencodeNET" Version="5.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Http" Version="8.0.0" />
     <PackageReference Include="System.IO.Pipelines" Version="8.0.0" />
     <PackageReference Include="Microsoft.Extensions.ObjectPool" Version="8.0.4" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.0" />

--- a/src/Torrential.Core/Trackers/AnnounceRequest.cs
+++ b/src/Torrential.Core/Trackers/AnnounceRequest.cs
@@ -1,0 +1,14 @@
+namespace Torrential.Core.Trackers;
+
+public class AnnounceRequest
+{
+    public required string Url { get; init; }
+    public required InfoHash InfoHash { get; init; }
+    public required PeerId PeerId { get; init; }
+    public required int Port { get; init; }
+
+    public int NumWant { get; init; } = 50;
+    public long BytesDownloaded { get; init; }
+    public long BytesRemaining { get; init; }
+    public long BytesUploaded { get; init; }
+}

--- a/src/Torrential.Core/Trackers/AnnounceResponse.cs
+++ b/src/Torrential.Core/Trackers/AnnounceResponse.cs
@@ -1,0 +1,11 @@
+namespace Torrential.Core.Trackers;
+
+public class AnnounceResponse
+{
+    public required int Interval { get; init; }
+    public int? MinInterval { get; init; }
+    public string TrackerId { get; init; }
+    public int Complete { get; init; }
+    public int Incomplete { get; init; }
+    public required ICollection<PeerInfo> Peers { get; init; }
+}

--- a/src/Torrential.Core/Trackers/Http/HttpTrackerClient.cs
+++ b/src/Torrential.Core/Trackers/Http/HttpTrackerClient.cs
@@ -1,0 +1,129 @@
+using BencodeNET.Objects;
+using BencodeNET.Parsing;
+using Microsoft.Extensions.Logging;
+using System.Net;
+using System.Web;
+
+namespace Torrential.Core.Trackers.Http;
+
+public class HttpTrackerClient : ITrackerClient
+{
+    private readonly HttpClient _client;
+    private readonly ILogger<HttpTrackerClient> _logger;
+
+    public HttpTrackerClient(HttpClient client, ILogger<HttpTrackerClient> logger)
+    {
+        _client = client;
+        _logger = logger;
+    }
+
+    public bool IsValidAnnounceForClient(string announceUrl)
+    {
+        return (announceUrl.StartsWith("http://") || announceUrl.StartsWith("https://")) && !announceUrl.Contains("ipv6");
+    }
+
+    public async Task<AnnounceResponse> Announce(AnnounceRequest request)
+    {
+        var info_hash = string.Create(60, request.InfoHash, (span, hash) =>
+        {
+            hash.WriteUrlEncodedHash(span);
+        });
+        var peer_id = HttpUtility.UrlEncode(request.PeerId.ToAsciiString());
+
+        try
+        {
+            using var response = await _client.GetAsync($"{request.Url}?info_hash={info_hash}&port={request.Port}&peer_id={peer_id}&numwant={request.NumWant}&no_peer_id=1&compact=1&downloaded={request.BytesDownloaded}&uploaded={request.BytesUploaded}&left={request.BytesRemaining}");
+
+            var parser = new BencodeParser();
+            var responseDictionary = parser.Parse<BDictionary>(await response.Content.ReadAsStreamAsync());
+
+            var interval = responseDictionary.Get<BNumber>("interval")?.Value ?? 0;
+            var seeders = responseDictionary.Get<BNumber>("complete")?.Value ?? 0;
+            var leechers = responseDictionary.Get<BNumber>("incomplete")?.Value ?? 0;
+            var trackerId = responseDictionary.Get<BString>("tracker id")?.ToString() ?? "";
+
+            if (!responseDictionary.TryGetValue("peers", out var bPeers))
+                throw new Exception("Announce response did not contain peers");
+
+            if (!TryParsePeers(bPeers, out var peers))
+                throw new Exception("Failed to parse peers");
+
+            return new AnnounceResponse
+            {
+                Interval = (int)interval,
+                Peers = peers,
+                Complete = (int)seeders,
+                Incomplete = (int)leechers,
+                TrackerId = trackerId
+            };
+        }
+        catch
+        {
+            return new AnnounceResponse
+            {
+                Interval = 60,
+                Peers = Array.Empty<PeerInfo>(),
+                Complete = 0,
+                Incomplete = 0,
+                TrackerId = ""
+            };
+        }
+    }
+
+    private bool TryParsePeers(IBObject bPeers, out PeerInfo[] peers)
+    {
+        peers = Array.Empty<PeerInfo>();
+        return bPeers switch
+        {
+            BString bPeerString => TryParsePeerString(bPeerString, out peers),
+            BList bPeersList => TryParsePeerList(bPeersList, out peers),
+            _ => false
+        };
+    }
+
+    private static bool TryParsePeerString(BString bPeersString, out PeerInfo[] peers)
+    {
+        try
+        {
+            var numOfPeers = bPeersString.Length / 6;
+            peers = new PeerInfo[numOfPeers];
+
+            Span<byte> portBytes = stackalloc byte[2];
+            for (int i = 0; i < numOfPeers; i++)
+            {
+                var ipSlice = bPeersString.Value.Span.Slice(i * 6, 4);
+                bPeersString.Value.Span.Slice(i * 6 + 4, 2).CopyTo(portBytes);
+                peers[i] = new PeerInfo(new IPAddress(ipSlice), portBytes.ReadBigEndianUInt16());
+            }
+
+            return true;
+        }
+        catch
+        {
+            peers = Array.Empty<PeerInfo>();
+            return false;
+        }
+    }
+
+    private static bool TryParsePeerList(BList bPeersList, out PeerInfo[] peers)
+    {
+        try
+        {
+            peers = new PeerInfo[bPeersList.Count];
+            for (int i = 0; i < bPeersList.Count; i++)
+            {
+                var peer = bPeersList[i] as BDictionary;
+                peers[i] = new PeerInfo(
+                    new IPAddress(peer.Get<BString>("ip").Value.Span),
+                    (int)peer.Get<BNumber>("port").Value);
+            }
+
+            return true;
+        }
+        catch
+        {
+            peers = Array.Empty<PeerInfo>();
+            return false;
+        }
+    }
+}

--- a/src/Torrential.Core/Trackers/ITrackerClient.cs
+++ b/src/Torrential.Core/Trackers/ITrackerClient.cs
@@ -1,0 +1,7 @@
+namespace Torrential.Core.Trackers;
+
+public interface ITrackerClient
+{
+    bool IsValidAnnounceForClient(string announceUrl);
+    Task<AnnounceResponse> Announce(AnnounceRequest request);
+}

--- a/src/Torrential.Core/Trackers/Udp/UdpTrackerClient.cs
+++ b/src/Torrential.Core/Trackers/Udp/UdpTrackerClient.cs
@@ -1,0 +1,125 @@
+using System.Buffers.Binary;
+using System.Net;
+using System.Net.Sockets;
+
+namespace Torrential.Core.Trackers.Udp;
+
+public class UdpTrackerClient : ITrackerClient
+{
+    public bool IsValidAnnounceForClient(string announceUrl)
+    {
+        return announceUrl.StartsWith("udp");
+    }
+
+    public Task<AnnounceResponse> Announce(AnnounceRequest request)
+    {
+        var uri = new Uri(request.Url);
+        using var client = new UdpClient(uri.Host, uri.Port);
+        var connectionResponse = SendConnectRequest(client);
+        var announceResponse = SendAnnounceRequest(client, connectionResponse.ConnectionId, connectionResponse.TransactionId, request.InfoHash, request.PeerId, 0, 0, 0, 2, 0, 0, request.NumWant, 0);
+        return Task.FromResult(announceResponse);
+    }
+
+    private UdpConnectionResponse SendConnectRequest(UdpClient client)
+    {
+        Span<byte> buffer = stackalloc byte[16];
+        var transactionId = Random.Shared.Next(0, 65535);
+        buffer.TryWriteBigEndian(0x41727101980);
+        buffer[12..].TryWriteBigEndian(transactionId);
+
+        client.Send(buffer);
+        IPEndPoint endPoint = null;
+        var recBuff = client.Receive(ref endPoint);
+
+        if (recBuff == null)
+            return UdpConnectionResponse.Failure(UdpConnectionError.NoResponse);
+        if (recBuff.Length < 0)
+            return UdpConnectionResponse.Failure(UdpConnectionError.NoData);
+        if (recBuff.Length < 16)
+            return UdpConnectionResponse.Failure(UdpConnectionError.PartialData);
+
+        var connectionId = recBuff.AsSpan().Slice(8).ReadBigEndianInt64();
+        return UdpConnectionResponse.Success(transactionId, connectionId);
+    }
+
+    private AnnounceResponse SendAnnounceRequest(UdpClient client, long connectionId, int transactionId, InfoHash infoHash, PeerId peerId, long downloaded, long left, long uploaded, int @event, int ipAddress, int key, int num_want, short port)
+    {
+        Span<byte> buffer = stackalloc byte[98];
+        buffer[..8].TryWriteBigEndian(connectionId);
+        buffer[8..].TryWriteBigEndian(1);
+        infoHash.CopyTo(buffer[16..]);
+        peerId.CopyTo(buffer[36..]);
+        buffer[56..].TryWriteBigEndian(downloaded);
+        buffer[64..].TryWriteBigEndian(left);
+        buffer[72..].TryWriteBigEndian(uploaded);
+        buffer[80..].TryWriteBigEndian(@event);
+        buffer[84..].TryWriteBigEndian(0);
+        buffer[88..].TryWriteBigEndian(key);
+        buffer[92..].TryWriteBigEndian(num_want);
+        BinaryPrimitives.WriteInt16BigEndian(buffer[96..], port);
+
+        client.Send(buffer);
+        IPEndPoint endPoint = null;
+        var recBuff = client.Receive(ref endPoint);
+
+        if (recBuff == null)
+            throw new Exception("UdpClient failed to receive");
+
+        if (recBuff.Length < 0)
+            throw new Exception("UdpClient received no response");
+
+        if (recBuff.Length < 20)
+            throw new Exception("UdpClient received a partial response");
+
+        if ((recBuff.Length - 20) % 6 != 0)
+            throw new Exception("UdpClient received a partial response");
+
+        var peers = new List<PeerInfo>();
+        var numOfPeers = (recBuff.Length - 20) / 6;
+        for (int n = 0; n < numOfPeers; n++)
+        {
+            var ipBytes = recBuff.AsSpan().Slice(20 + (6 * n), 4);
+            var portBytes = recBuff.AsSpan().Slice(24 + (6 * n), 2);
+            var ip = new IPAddress(ipBytes);
+            var peerPort = portBytes.ReadBigEndianUInt16();
+            peers.Add(new PeerInfo(ip, peerPort));
+        }
+
+        return new AnnounceResponse
+        {
+            Interval = recBuff.AsSpan()[8..].ReadBigEndianInt32(),
+            Peers = peers
+        };
+    }
+
+    internal enum UdpConnectionError
+    {
+        NoResponse,
+        NoData,
+        PartialData
+    }
+
+    internal readonly struct UdpConnectionResponse
+    {
+        public readonly int TransactionId;
+        public readonly long ConnectionId;
+        public readonly UdpConnectionError? Error;
+        public readonly bool HasError;
+
+        public static UdpConnectionResponse Success(int transactionId, long connectionId) => new UdpConnectionResponse(transactionId, connectionId);
+        public static UdpConnectionResponse Failure(UdpConnectionError error) => new UdpConnectionResponse(error);
+
+        private UdpConnectionResponse(int transactionId, long connectionId)
+        {
+            TransactionId = transactionId;
+            ConnectionId = connectionId;
+            HasError = false;
+        }
+
+        private UdpConnectionResponse(UdpConnectionError error)
+        {
+            Error = error;
+            HasError = true;
+        }
+    }
+}


### PR DESCRIPTION
Add Udp and Http tracker clients to Torrential.Core. Take inspiration from the ones in Torrential

## Subtasks
- [x] **Phase 1** — Add tracker models and interface
  Create the ITrackerClient interface, AnnounceRequest, and AnnounceResponse types in Torrential.Core, plus add required NuGet dependencies
- [x] **Phase 1** — Implement HTTP tracker client
  Port the HTTP tracker client from Torrential to Torrential.Core using Core types
- [x] **Phase 1** — Implement UDP tracker client
  Port the UDP tracker client from Torrential to Torrential.Core using Core types

**Total cost:** $0.0000
