### PR TITLE
feat: Add TcpListener

### DIFF
--- a/src/Torrential.Application/IInboundConnectionHandler.cs
+++ b/src/Torrential.Application/IInboundConnectionHandler.cs
@@ -1,0 +1,9 @@
+using Torrential.Core;
+
+namespace Torrential.Application;
+
+public interface IInboundConnectionHandler
+{
+    Task<bool> IsBlockedAsync(IPeerWireConnection connection);
+    Task HandleAsync(IPeerWireConnection connection);
+}

--- a/src/Torrential.Application/ITcpListenerSettings.cs
+++ b/src/Torrential.Application/ITcpListenerSettings.cs
@@ -1,0 +1,7 @@
+namespace Torrential.Application;
+
+public interface ITcpListenerSettings
+{
+    bool Enabled { get; }
+    int Port { get; }
+}

--- a/src/Torrential.Application/ServiceCollectionExtensions.cs
+++ b/src/Torrential.Application/ServiceCollectionExtensions.cs
@@ -7,6 +7,7 @@ public static class ServiceCollectionExtensions
     public static IServiceCollection AddTorrentApplication(this IServiceCollection services)
     {
         services.AddSingleton<ITorrentManager, TorrentManager>();
+        services.AddHostedService<TcpListenerService>();
         return services;
     }
 }

--- a/src/Torrential.Application/TcpListenerService.cs
+++ b/src/Torrential.Application/TcpListenerService.cs
@@ -1,0 +1,85 @@
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using System.Net;
+using System.Net.Sockets;
+using Torrential.Core;
+
+namespace Torrential.Application;
+
+public sealed class TcpListenerService(
+    IInboundConnectionHandler connectionHandler,
+    ITcpListenerSettings settings,
+    ILogger<IPeerWireConnection> pwcLogger,
+    ILogger<TcpListenerService> logger)
+    : BackgroundService
+{
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        await AcceptConnections(stoppingToken);
+    }
+
+    private async Task AcceptConnections(CancellationToken stoppingToken)
+    {
+        TcpListener? tcpListener = null;
+        int? port = null;
+
+        while (!stoppingToken.IsCancellationRequested)
+        {
+            var newPort = await WaitForEnabled(stoppingToken);
+            if (!port.HasValue || newPort != port)
+            {
+                tcpListener?.Stop();
+                tcpListener?.Dispose();
+                tcpListener = new TcpListener(IPAddress.Any, newPort);
+                tcpListener.Server.SetSocketOption(SocketOptionLevel.Socket, SocketOptionName.ReuseAddress, true);
+                tcpListener.Start();
+                port = newPort;
+                logger.LogInformation("TCP Listener started on {Port}", port);
+            }
+
+            try
+            {
+                var socket = await tcpListener!.AcceptSocketAsync(stoppingToken);
+                if (socket == null) continue;
+
+                socket.SetSocketOption(SocketOptionLevel.Socket, SocketOptionName.KeepAlive, true);
+                if (!socket.Connected)
+                {
+                    socket.Dispose();
+                    continue;
+                }
+
+                var connection = new PeerWireSocketConnection(socket, pwcLogger);
+                if (await connectionHandler.IsBlockedAsync(connection))
+                {
+                    logger.LogInformation("Disposing blocked connection");
+                    await connection.DisposeAsync();
+                    continue;
+                }
+
+                await connectionHandler.HandleAsync(connection);
+            }
+            catch (OperationCanceledException) when (stoppingToken.IsCancellationRequested)
+            {
+                break;
+            }
+            catch (Exception ex)
+            {
+                logger.LogError(ex, "Error accepting connection");
+            }
+        }
+
+        tcpListener?.Stop();
+        tcpListener?.Dispose();
+    }
+
+    private async ValueTask<int> WaitForEnabled(CancellationToken stoppingToken)
+    {
+        while (!stoppingToken.IsCancellationRequested && !settings.Enabled)
+        {
+            await Task.Delay(1000, stoppingToken);
+        }
+
+        return settings.Port;
+    }
+}

--- a/src/Torrential.Application/Torrential.Application.csproj
+++ b/src/Torrential.Application/Torrential.Application.csproj
@@ -7,6 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="8.0.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.0" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.0" />
   </ItemGroup>


### PR DESCRIPTION
Add a TcpListener service to `Torrential.Application`. Take inspiration from the existing implementation in `Torrential`

## Subtasks
- [x] **Phase 1** — Add TcpListener service to Torrential.Application
  Create TcpListenerService BackgroundService, ITcpListenerSettings, and IInboundConnectionHandler interfaces in Torrential.Application, modeled on the existing TcpPeerListenerBackgroundService

**Total cost:** $0.0000
