### PR TITLE
feat: Add InboundConnectionHandler implmentation

### DIFF
--- a/src/Torrential.Application/InboundConnectionHandler.cs
+++ b/src/Torrential.Application/InboundConnectionHandler.cs
@@ -1,0 +1,58 @@
+using Microsoft.Extensions.Logging;
+using Torrential.Core;
+
+namespace Torrential.Application;
+
+public sealed class InboundConnectionHandler : IInboundConnectionHandler
+{
+    private readonly HandshakeService _handshakeService;
+    private readonly ITorrentManager _torrentManager;
+    private readonly ILogger<InboundConnectionHandler> _logger;
+    private readonly PeerId _selfId = PeerId.New;
+
+    public InboundConnectionHandler(
+        HandshakeService handshakeService,
+        ITorrentManager torrentManager,
+        ILogger<InboundConnectionHandler> logger)
+    {
+        _handshakeService = handshakeService;
+        _torrentManager = torrentManager;
+        _logger = logger;
+    }
+
+    public async Task<bool> HandleAsync(IPeerWireConnection connection, CancellationToken cancellationToken)
+    {
+        try
+        {
+            using var handshakeCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+            handshakeCts.CancelAfter(5_000);
+
+            var response = await _handshakeService.HandleInbound(
+                connection.Writer,
+                connection.Reader,
+                _selfId,
+                infoHash => _torrentManager.GetState(infoHash) != null,
+                handshakeCts.Token);
+
+            if (!response.Success)
+            {
+                _logger.LogInformation("Inbound handshake failed - {Ip}", connection.PeerInfo.Ip);
+                return false;
+            }
+
+            connection.SetInfoHash(response.InfoHash);
+            connection.SetPeerId(response.PeerId);
+            return true;
+        }
+        catch (OperationCanceledException)
+        {
+            _logger.LogError("Handshake timed out, closing connection");
+            return false;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Inbound handshake failed");
+            return false;
+        }
+    }
+}

--- a/src/Torrential.Application/ServiceCollectionExtensions.cs
+++ b/src/Torrential.Application/ServiceCollectionExtensions.cs
@@ -1,4 +1,5 @@
 using Microsoft.Extensions.DependencyInjection;
+using Torrential.Core;
 
 namespace Torrential.Application;
 
@@ -7,6 +8,7 @@ public static class ServiceCollectionExtensions
     public static IServiceCollection AddTorrentApplication(this IServiceCollection services)
     {
         services.AddSingleton<ITorrentManager, TorrentManager>();
+        services.AddSingleton<IInboundConnectionHandler, InboundConnectionHandler>();
         return services;
     }
 }

--- a/src/Torrential.Core/IInboundConnectionHandler.cs
+++ b/src/Torrential.Core/IInboundConnectionHandler.cs
@@ -1,0 +1,6 @@
+namespace Torrential.Core;
+
+public interface IInboundConnectionHandler
+{
+    Task<bool> HandleAsync(IPeerWireConnection connection, CancellationToken cancellationToken);
+}


### PR DESCRIPTION
Add an implementation of the IInboundConnectionHandler. Take inspiration from the existing half open connection handler

## Subtasks
- [x] **Phase 1** — Create IInboundConnectionHandler interface and implementation
  Define the IInboundConnectionHandler interface in Torrential.Core and implement InboundConnectionHandler in Torrential.Application, modeled after the existing HalfOpenConnectionShakerService.ConnectInbound pattern. Register in DI.

**Total cost:** $0.0000
