### PR TITLE
feat: Wire up torrent management

### DIFF
--- a/src/torrential-frontend/src/lib/api/client.ts
+++ b/src/torrential-frontend/src/lib/api/client.ts
@@ -1,25 +1,28 @@
-import type { TorrentState, AddTorrentRequest } from './types';
+import type { TorrentState } from './types';
 
 const BASE = '/api';
 
 export async function listTorrents(): Promise<TorrentState[]> {
   const res = await fetch(`${BASE}/torrents`);
   if (!res.ok) throw new Error('Failed to fetch torrents');
-  return res.json();
+  const body = await res.json();
+  return body.data ?? [];
 }
 
 export async function getTorrent(infoHash: string): Promise<TorrentState | null> {
   const res = await fetch(`${BASE}/torrents/${infoHash}`);
   if (res.status === 404) return null;
   if (!res.ok) throw new Error('Failed to fetch torrent');
-  return res.json();
+  const body = await res.json();
+  return body.data ?? null;
 }
 
-export async function addTorrent(request: AddTorrentRequest): Promise<void> {
-  const res = await fetch(`${BASE}/torrents`, {
+export async function addTorrent(file: File): Promise<void> {
+  const formData = new FormData();
+  formData.append('file', file);
+  const res = await fetch(`${BASE}/torrents/add`, {
     method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify(request),
+    body: formData,
   });
   if (!res.ok) throw new Error('Failed to add torrent');
 }
@@ -34,7 +37,11 @@ export async function stopTorrent(infoHash: string): Promise<void> {
   if (!res.ok) throw new Error('Failed to stop torrent');
 }
 
-export async function removeTorrent(infoHash: string, deleteData = false): Promise<void> {
-  const res = await fetch(`${BASE}/torrents/${infoHash}?deleteData=${deleteData}`, { method: 'DELETE' });
+export async function removeTorrent(infoHash: string, deleteFiles = false): Promise<void> {
+  const res = await fetch(`${BASE}/torrents/${infoHash}/delete`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ deleteFiles }),
+  });
   if (!res.ok) throw new Error('Failed to remove torrent');
 }

--- a/src/torrential-frontend/src/lib/api/types.ts
+++ b/src/torrential-frontend/src/lib/api/types.ts
@@ -1,38 +1,22 @@
-export interface TorrentFileInfo {
-  fileIndex: number;
-  fileName: string;
-  fileSize: number;
+export interface PeerSummary {
+  peerId: string;
+  ipAddress: string;
+  port: number;
+  bytesDownloaded: number;
+  bytesUploaded: number;
+  isSeed: boolean;
+  progress: number;
 }
 
 export interface TorrentState {
   infoHash: string;
   name: string;
-  totalSize: number;
-  files: TorrentFileInfo[];
-  selectedFileIndices: number[];
-  status: 'Added' | 'Downloading' | 'Stopped' | 'Completed' | 'Error';
-  dateAdded: string;
-}
-
-export interface AddTorrentFileRequest {
-  fileIndex: number;
-  fileName: string;
-  fileSize: number;
-}
-
-export interface AddTorrentFileSelectionRequest {
-  fileIndex: number;
-  selected: boolean;
-}
-
-export interface AddTorrentRequest {
-  name: string;
-  infoHash: string;
-  totalSize: number;
-  pieceSize: number;
-  numberOfPieces: number;
-  files: AddTorrentFileRequest[];
-  announceUrls: string[];
-  pieceHashes: string;
-  fileSelections?: AddTorrentFileSelectionRequest[];
+  progress: number;
+  bytesDownloaded: number;
+  bytesUploaded: number;
+  downloadRate: number;
+  uploadRate: number;
+  totalSizeBytes: number;
+  peers: PeerSummary[];
+  status: 'Running' | 'Stopped' | 'Idle';
 }


### PR DESCRIPTION
Wire up the torrent management actions to the frontend. I should be able to add a torrent and pick from a file on my machine. I should be able to then delete that torrent from the list as well.

## Subtasks
- [x] **Phase 1** — Fix API client to match backend endpoints
  Fix the torrential-frontend API client so that all methods match the actual backend API signatures (response wrapping, HTTP methods, upload format, delete endpoint).
- [x] **Phase 2** — Wire up Add Torrent file picker and Delete torrent in the UI
  Add a file input for .torrent file selection to the Add Torrent button, wire it to the fixed API client's addTorrent function, and ensure the delete flow uses the updated removeTorrent API. Update status display to match backend status values.

**Total cost:** $0.0000
