### PR TITLE
feat: Settings page

### DIFF
--- a/src/Torrential.Api/Program.cs
+++ b/src/Torrential.Api/Program.cs
@@ -136,6 +136,21 @@ torrents.MapPost("/{infoHash}/files", (InfoHash infoHash, UpdateFileSelectionsRe
     return ToHttpResult(manager.UpdateFileSelections(infoHash, selections));
 });
 
+var settings = app.MapGroup("/settings");
+
+settings.MapGet("/", async (ISettingsService settingsService) =>
+    Results.Ok(await settingsService.GetSettingsAsync()));
+
+settings.MapPut("/", async (UpdateSettingsRequest request, ISettingsService settingsService) =>
+{
+    var updated = await settingsService.UpdateSettingsAsync(
+        request.DownloadFolder,
+        request.CompletedFolder,
+        request.MaxHalfOpenConnections,
+        request.MaxPeersPerTorrent);
+    return Results.Ok(updated);
+});
+
 app.Run();
 
 static IResult ToHttpResult(TorrentManagerResult result)
@@ -238,3 +253,9 @@ public record PeerDetailDto(
 
 public record UpdateFileSelectionItem(int FileIndex, bool Selected);
 public record UpdateFileSelectionsRequest(List<UpdateFileSelectionItem> FileSelections);
+
+public record UpdateSettingsRequest(
+    string DownloadFolder,
+    string CompletedFolder,
+    int MaxHalfOpenConnections,
+    int MaxPeersPerTorrent);

--- a/src/Torrential.Application/ISettingsService.cs
+++ b/src/Torrential.Application/ISettingsService.cs
@@ -1,0 +1,9 @@
+using Torrential.Application.Persistence;
+
+namespace Torrential.Application;
+
+public interface ISettingsService
+{
+    Task<SettingsEntity> GetSettingsAsync();
+    Task<SettingsEntity> UpdateSettingsAsync(string downloadFolder, string completedFolder, int maxHalfOpenConnections, int maxPeersPerTorrent);
+}

--- a/src/Torrential.Application/Persistence/Migrations/20260215191421_AddSettings.Designer.cs
+++ b/src/Torrential.Application/Persistence/Migrations/20260215191421_AddSettings.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Torrential.Application.Persistence;
 
@@ -10,9 +11,11 @@ using Torrential.Application.Persistence;
 namespace Torrential.Application.Persistence.Migrations
 {
     [DbContext(typeof(TorrentDbContext))]
-    partial class TorrentDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260215191421_AddSettings")]
+    partial class AddSettings
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder.HasAnnotation("ProductVersion", "10.0.0");

--- a/src/Torrential.Application/Persistence/Migrations/20260215191421_AddSettings.cs
+++ b/src/Torrential.Application/Persistence/Migrations/20260215191421_AddSettings.cs
@@ -1,0 +1,37 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Torrential.Application.Persistence.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddSettings : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "Settings",
+                columns: table => new
+                {
+                    Id = table.Column<int>(type: "INTEGER", nullable: false)
+                        .Annotation("Sqlite:Autoincrement", true),
+                    DownloadFolder = table.Column<string>(type: "TEXT", nullable: false),
+                    CompletedFolder = table.Column<string>(type: "TEXT", nullable: false),
+                    MaxHalfOpenConnections = table.Column<int>(type: "INTEGER", nullable: false),
+                    MaxPeersPerTorrent = table.Column<int>(type: "INTEGER", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_Settings", x => x.Id);
+                });
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "Settings");
+        }
+    }
+}

--- a/src/Torrential.Application/Persistence/SettingsEntity.cs
+++ b/src/Torrential.Application/Persistence/SettingsEntity.cs
@@ -1,0 +1,10 @@
+namespace Torrential.Application.Persistence;
+
+public class SettingsEntity
+{
+    public int Id { get; set; } = 1;
+    public string DownloadFolder { get; set; } = "/downloads";
+    public string CompletedFolder { get; set; } = "/downloads/completed";
+    public int MaxHalfOpenConnections { get; set; } = 50;
+    public int MaxPeersPerTorrent { get; set; } = 50;
+}

--- a/src/Torrential.Application/Persistence/TorrentDbContext.cs
+++ b/src/Torrential.Application/Persistence/TorrentDbContext.cs
@@ -5,6 +5,7 @@ namespace Torrential.Application.Persistence;
 public class TorrentDbContext(DbContextOptions<TorrentDbContext> options) : DbContext(options)
 {
     public DbSet<TorrentEntity> Torrents => Set<TorrentEntity>();
+    public DbSet<SettingsEntity> Settings => Set<SettingsEntity>();
 
     protected override void OnModelCreating(ModelBuilder modelBuilder)
     {
@@ -12,6 +13,11 @@ public class TorrentDbContext(DbContextOptions<TorrentDbContext> options) : DbCo
         {
             entity.HasKey(e => e.InfoHash);
             entity.Property(e => e.InfoHash).HasMaxLength(40);
+        });
+
+        modelBuilder.Entity<SettingsEntity>(entity =>
+        {
+            entity.HasKey(e => e.Id);
         });
     }
 }

--- a/src/Torrential.Application/ServiceCollectionExtensions.cs
+++ b/src/Torrential.Application/ServiceCollectionExtensions.cs
@@ -17,6 +17,7 @@ public static class ServiceCollectionExtensions
             options.UseSqlite($"Data Source={dbPath}"));
 
         services.AddSingleton<ITorrentManager, TorrentManager>();
+        services.AddSingleton<ISettingsService, SettingsService>();
         services.AddHostedService<TorrentStoreInitializer>();
         services.AddSingleton<IInboundConnectionHandler, InboundConnectionHandler>();
         services.AddHostedService<TcpListenerService>();

--- a/src/Torrential.Application/SettingsService.cs
+++ b/src/Torrential.Application/SettingsService.cs
@@ -1,0 +1,45 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Torrential.Application.Persistence;
+
+namespace Torrential.Application;
+
+public class SettingsService(IServiceScopeFactory scopeFactory) : ISettingsService
+{
+    private TorrentDbContext CreateDbContext()
+    {
+        var scope = scopeFactory.CreateScope();
+        return scope.ServiceProvider.GetRequiredService<TorrentDbContext>();
+    }
+
+    public async Task<SettingsEntity> GetSettingsAsync()
+    {
+        using var db = CreateDbContext();
+        var settings = await db.Settings.FindAsync(1);
+        if (settings is not null) return settings;
+
+        settings = new SettingsEntity();
+        db.Settings.Add(settings);
+        await db.SaveChangesAsync();
+        return settings;
+    }
+
+    public async Task<SettingsEntity> UpdateSettingsAsync(string downloadFolder, string completedFolder, int maxHalfOpenConnections, int maxPeersPerTorrent)
+    {
+        using var db = CreateDbContext();
+        var settings = await db.Settings.FindAsync(1);
+        if (settings is null)
+        {
+            settings = new SettingsEntity();
+            db.Settings.Add(settings);
+        }
+
+        settings.DownloadFolder = downloadFolder;
+        settings.CompletedFolder = completedFolder;
+        settings.MaxHalfOpenConnections = maxHalfOpenConnections;
+        settings.MaxPeersPerTorrent = maxPeersPerTorrent;
+
+        await db.SaveChangesAsync();
+        return settings;
+    }
+}

--- a/src/torrential-frontend/src/lib/api/client.ts
+++ b/src/torrential-frontend/src/lib/api/client.ts
@@ -1,4 +1,4 @@
-import type { TorrentState, ParsedTorrent, TorrentDetails } from './types';
+import type { TorrentState, ParsedTorrent, TorrentDetails, Settings } from './types';
 
 const BASE = '/api';
 
@@ -86,4 +86,20 @@ export async function updateFileSelections(
     body: JSON.stringify({ fileSelections }),
   });
   if (!res.ok) throw new Error('Failed to update file selections');
+}
+
+export async function getSettings(): Promise<Settings> {
+  const res = await fetch(`${BASE}/settings`);
+  if (!res.ok) throw new Error('Failed to fetch settings');
+  return res.json();
+}
+
+export async function updateSettings(settings: Omit<Settings, 'id'>): Promise<Settings> {
+  const res = await fetch(`${BASE}/settings`, {
+    method: 'PUT',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(settings),
+  });
+  if (!res.ok) throw new Error('Failed to update settings');
+  return res.json();
 }

--- a/src/torrential-frontend/src/lib/api/types.ts
+++ b/src/torrential-frontend/src/lib/api/types.ts
@@ -68,3 +68,11 @@ export interface PeerDetail {
   progress: number;
   pieces: boolean[];
 }
+
+export interface Settings {
+  id: number;
+  downloadFolder: string;
+  completedFolder: string;
+  maxHalfOpenConnections: number;
+  maxPeersPerTorrent: number;
+}

--- a/src/torrential-frontend/src/pages/settings.tsx
+++ b/src/torrential-frontend/src/pages/settings.tsx
@@ -1,16 +1,127 @@
+import { useCallback, useEffect, useState } from 'react'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+import { Input } from '@/components/ui/input'
+import { Button } from '@/components/ui/button'
+import { getSettings, updateSettings } from '@/lib/api'
 
 export function SettingsPage() {
+  const [loading, setLoading] = useState(true)
+  const [saving, setSaving] = useState(false)
+  const [downloadFolder, setDownloadFolder] = useState('')
+  const [completedFolder, setCompletedFolder] = useState('')
+  const [maxHalfOpenConnections, setMaxHalfOpenConnections] = useState(0)
+  const [maxPeersPerTorrent, setMaxPeersPerTorrent] = useState(0)
+
+  const fetchSettings = useCallback(async () => {
+    try {
+      const data = await getSettings()
+      setDownloadFolder(data.downloadFolder)
+      setCompletedFolder(data.completedFolder)
+      setMaxHalfOpenConnections(data.maxHalfOpenConnections)
+      setMaxPeersPerTorrent(data.maxPeersPerTorrent)
+    } catch (e) {
+      console.error('Failed to fetch settings', e)
+    } finally {
+      setLoading(false)
+    }
+  }, [])
+
+  useEffect(() => {
+    fetchSettings()
+  }, [fetchSettings])
+
+  const handleSave = async () => {
+    setSaving(true)
+    try {
+      const updated = await updateSettings({
+        downloadFolder,
+        completedFolder,
+        maxHalfOpenConnections,
+        maxPeersPerTorrent,
+      })
+      setDownloadFolder(updated.downloadFolder)
+      setCompletedFolder(updated.completedFolder)
+      setMaxHalfOpenConnections(updated.maxHalfOpenConnections)
+      setMaxPeersPerTorrent(updated.maxPeersPerTorrent)
+    } catch (e) {
+      console.error('Failed to save settings', e)
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  if (loading) {
+    return (
+      <div className="flex flex-1 items-center justify-center p-6">
+        <p className="text-muted-foreground text-sm">Loading settings...</p>
+      </div>
+    )
+  }
+
   return (
-    <div className="flex flex-1 items-center justify-center p-6">
-      <Card className="w-full max-w-md">
+    <div className="flex flex-1 justify-center p-6">
+      <Card className="w-full max-w-2xl h-fit">
         <CardHeader>
           <CardTitle>Settings</CardTitle>
         </CardHeader>
-        <CardContent>
-          <p className="text-muted-foreground text-sm">
-            Settings will be available in a future update.
-          </p>
+        <CardContent className="flex flex-col gap-6">
+          <div className="flex flex-col gap-4">
+            <h3 className="text-sm font-semibold">Folders</h3>
+            <div className="flex flex-col gap-1.5">
+              <label className="text-sm font-medium">Download Folder</label>
+              <Input
+                value={downloadFolder}
+                onChange={(e) => setDownloadFolder(e.target.value)}
+              />
+              <p className="text-muted-foreground text-xs">
+                Directory where active downloads are saved
+              </p>
+            </div>
+            <div className="flex flex-col gap-1.5">
+              <label className="text-sm font-medium">Completed Folder</label>
+              <Input
+                value={completedFolder}
+                onChange={(e) => setCompletedFolder(e.target.value)}
+              />
+              <p className="text-muted-foreground text-xs">
+                Directory where completed downloads are moved
+              </p>
+            </div>
+          </div>
+
+          <div className="flex flex-col gap-4">
+            <h3 className="text-sm font-semibold">Connection Limits</h3>
+            <div className="flex flex-col gap-1.5">
+              <label className="text-sm font-medium">Max Half-Open Connections</label>
+              <Input
+                type="number"
+                min={1}
+                value={maxHalfOpenConnections}
+                onChange={(e) => setMaxHalfOpenConnections(Number(e.target.value))}
+              />
+              <p className="text-muted-foreground text-xs">
+                Maximum number of simultaneous half-open connections
+              </p>
+            </div>
+            <div className="flex flex-col gap-1.5">
+              <label className="text-sm font-medium">Max Peers Per Torrent</label>
+              <Input
+                type="number"
+                min={1}
+                value={maxPeersPerTorrent}
+                onChange={(e) => setMaxPeersPerTorrent(Number(e.target.value))}
+              />
+              <p className="text-muted-foreground text-xs">
+                Maximum number of peers to connect to per torrent
+              </p>
+            </div>
+          </div>
+
+          <div className="flex justify-end">
+            <Button onClick={handleSave} disabled={saving}>
+              {saving ? 'Saving...' : 'Save'}
+            </Button>
+          </div>
         </CardContent>
       </Card>
     </div>


### PR DESCRIPTION
I want to build out the settings page now such that it persists the settings all the way through to the backend the setting should contain the download and completed folders as well as the maximum number of half open connections, and number of Max peers  per torrent

## Subtasks
- [x] **Phase 1** — Backend settings persistence and API
  Create SettingsEntity, add DbSet to TorrentDbContext, create EF migration, build ISettingsService with get/update, register in DI, and add GET/PUT /settings API endpoints
- [x] **Phase 2** — Frontend settings page
  Build the settings form UI with inputs for download/completed folders and max connections/peers, wire it to the new GET/PUT /settings API, and handle loading/saving state
- [x] **Phase 3** — E2E screenshot verification
  Run the Playwright screenshot pipeline and visually verify the settings page renders correctly

**Total cost:** $0.0000
