### PR TITLE
feat: Piece Suggestion and download buffer

### DIFF
--- a/src/Torrential/Files/InMemoryBlockSaveService.cs
+++ b/src/Torrential/Files/InMemoryBlockSaveService.cs
@@ -1,0 +1,63 @@
+using MassTransit;
+using Microsoft.Extensions.Logging;
+using Torrential.Peers;
+using Torrential.Torrents;
+
+namespace Torrential.Files;
+
+internal class InMemoryBlockSaveService(
+    TorrentMetadataCache metaCache,
+    ILogger<InMemoryBlockSaveService> logger,
+    BitfieldManager bitfieldManager,
+    IBus bus,
+    PieceBufferManager pieceBufferManager,
+    PieceReservationService pieceReservationService)
+    : IBlockSaveService
+{
+    public async Task SaveBlock(PooledBlock block)
+    {
+        using (block)
+        {
+            if (!metaCache.TryGet(block.InfoHash, out var meta))
+                return;
+
+            if (!bitfieldManager.TryGetVerificationBitfield(block.InfoHash, out var verificationBitfield))
+                return;
+
+            if (verificationBitfield.HasPiece(block.PieceIndex))
+                return;
+
+            var pieceLength = (int)(block.PieceIndex == meta.NumberOfPieces - 1 ? meta.FinalPieceSize : meta.PieceSize);
+
+            var buffer = pieceBufferManager.GetOrCreateBuffer(block.InfoHash, block.PieceIndex, pieceLength, block.SenderPeerId);
+
+            if (!buffer.TryAddBlock(block.Buffer, block.Offset, block.SenderPeerId))
+                return;
+
+            await bus.Publish(new TorrentBlockDownloaded { InfoHash = meta.InfoHash, Length = block.Buffer.Length });
+
+            if (buffer.IsComplete)
+            {
+                var expectedHash = meta.GetPieceHash(block.PieceIndex);
+                var valid = buffer.VerifyHash(expectedHash);
+
+                if (valid)
+                {
+                    await verificationBitfield.MarkHaveAsync(block.PieceIndex, CancellationToken.None);
+                    await bus.Publish(new TorrentPieceVerifiedEvent { InfoHash = block.InfoHash, PieceIndex = block.PieceIndex, Progress = verificationBitfield.CompletionRatio });
+                    logger.LogInformation("Piece {PieceIndex} verified successfully", block.PieceIndex);
+
+                    if (verificationBitfield.HasAll())
+                        await bus.Publish(new TorrentCompleteEvent { InfoHash = block.InfoHash });
+                }
+                else
+                {
+                    logger.LogWarning("Piece {PieceIndex} failed verification, releasing reservation", block.PieceIndex);
+                    pieceReservationService.ReleasePiece(block.InfoHash, block.PieceIndex);
+                }
+
+                pieceBufferManager.RemoveBuffer(block.InfoHash, block.PieceIndex);
+            }
+        }
+    }
+}

--- a/src/Torrential/Peers/BitfieldManager.cs
+++ b/src/Torrential/Peers/BitfieldManager.cs
@@ -11,7 +11,6 @@ namespace Torrential.Peers
         private ConcurrentDictionary<InfoHash, AsyncBitfield> _downloadBitfields = [];
         private ConcurrentDictionary<InfoHash, AsyncBitfield> _verificationBitfields = [];
         private ConcurrentDictionary<InfoHash, AsyncBitfield> _blockBitfields = [];
-        private ConcurrentDictionary<InfoHash, AsyncBitfield> _pieceReservationBitfields = [];
 
         public ICollection<(InfoHash, AsyncBitfield)> DownloadBitfields => _downloadBitfields.Select(Bitfield => (Bitfield.Key, Bitfield.Value)).ToArray();
         public ICollection<(InfoHash, AsyncBitfield)> VerificationBitfields => _verificationBitfields.Select(Bitfield => (Bitfield.Key, Bitfield.Value)).ToArray();
@@ -21,7 +20,6 @@ namespace Torrential.Peers
             _downloadBitfields.TryRemove(infoHash, out _);
             _verificationBitfields.TryRemove(infoHash, out _);
             _blockBitfields.TryRemove(infoHash, out _);
-            _pieceReservationBitfields.TryRemove(infoHash, out _);
         }
 
         public async Task Initialize(TorrentMetadata meta)
@@ -40,8 +38,6 @@ namespace Torrential.Peers
             if (!verificationBitfield.HasAll())
             {
                 var blockBitfield = new AsyncBitfield(meta.TotalNumberOfChunks);
-                var pieceReservationBitfield = new AsyncBitfield(numPieces);
-                _pieceReservationBitfields[infoHash] = pieceReservationBitfield;
                 _blockBitfields[infoHash] = blockBitfield;
             }
 
@@ -70,12 +66,6 @@ namespace Torrential.Peers
         {
             return _verificationBitfields.TryGetValue(infoHash, out bitfield);
         }
-
-        public bool TryGetPieceReservationBitfield(InfoHash infoHash, out AsyncBitfield bitfield)
-        {
-            return _pieceReservationBitfields.TryGetValue(infoHash, out bitfield);
-        }
-
 
         private async ValueTask LoadDownloadBitfieldData(InfoHash infoHash, AsyncBitfield bitField)
         {

--- a/src/Torrential/Peers/PeerSwarm.cs
+++ b/src/Torrential/Peers/PeerSwarm.cs
@@ -16,6 +16,7 @@ namespace Torrential.Peers
         SettingsManager settingsManager,
         TorrentStatusCache statusCache,
         BitfieldManager bitfieldManager,
+        PieceReservationService pieceReservationService,
         IBus bus,
         IBlockSaveService blockSaveService,
         ILogger<PeerSwarm> logger,
@@ -304,6 +305,9 @@ namespace Torrential.Peers
                     await peerClient.DisposeAsync();
                 }
             }
+
+            //Release all piece reservations held by this peer
+            pieceReservationService.ReleaseAllForPeer(infoHash, peerId);
 
             //Notify that the peer has been removed
             await bus.Publish(new PeerDisconnectedEvent

--- a/src/Torrential/Peers/PeerWireClient.cs
+++ b/src/Torrential/Peers/PeerWireClient.cs
@@ -354,7 +354,7 @@ public sealed class PeerWireClient : IAsyncDisposable
 
     private async ValueTask<bool> HandlePieceAsync(ReadOnlySequence<byte> payload, int chunkSize)
     {
-        var block = PooledBlock.FromReadOnlySequence(payload, chunkSize, _infoHash);
+        var block = PooledBlock.FromReadOnlySequence(payload, chunkSize, _infoHash, PeerId);
         await INBOUND_BLOCK_CHANNEL.Writer.WriteAsync(block, _cts.Token);
         BytesDownloaded += block.Buffer.Length;
         return true;

--- a/src/Torrential/Peers/PieceBuffer.cs
+++ b/src/Torrential/Peers/PieceBuffer.cs
@@ -1,0 +1,64 @@
+using System.Buffers;
+using System.Security.Cryptography;
+
+namespace Torrential.Peers;
+
+public sealed class PieceBuffer : IDisposable
+{
+    private readonly byte[] _buffer;
+    private readonly int _pieceLength;
+    private readonly int _blockSize = 16384;
+    private readonly int _totalBlocks;
+    private readonly bool[] _receivedBlocks;
+    private int _blocksReceived;
+
+    public PeerId Owner { get; private set; }
+    public int PieceIndex { get; }
+
+    public PieceBuffer(int pieceIndex, int pieceLength, PeerId owner)
+    {
+        PieceIndex = pieceIndex;
+        _pieceLength = pieceLength;
+        Owner = owner;
+        _buffer = ArrayPool<byte>.Shared.Rent(pieceLength);
+        _totalBlocks = (pieceLength + _blockSize - 1) / _blockSize;
+        _receivedBlocks = new bool[_totalBlocks];
+    }
+
+    public bool TryAddBlock(ReadOnlySpan<byte> blockData, int offset, PeerId sender)
+    {
+        if (sender != Owner)
+            return false;
+
+        var blockIndex = offset / _blockSize;
+        if (blockIndex < 0 || blockIndex >= _totalBlocks)
+            return false;
+
+        if (_receivedBlocks[blockIndex])
+            return false;
+
+        blockData.CopyTo(_buffer.AsSpan(offset, blockData.Length));
+        _receivedBlocks[blockIndex] = true;
+        _blocksReceived++;
+        return true;
+    }
+
+    public bool IsComplete => _blocksReceived == _totalBlocks;
+
+    public bool VerifyHash(ReadOnlySpan<byte> expectedHash)
+    {
+        Span<byte> hash = stackalloc byte[20];
+        SHA1.HashData(_buffer.AsSpan(0, _pieceLength), hash);
+        return hash.SequenceEqual(expectedHash);
+    }
+
+    public void Reassign(PeerId newOwner)
+    {
+        Owner = newOwner;
+    }
+
+    public void Dispose()
+    {
+        ArrayPool<byte>.Shared.Return(_buffer);
+    }
+}

--- a/src/Torrential/Peers/PieceBufferManager.cs
+++ b/src/Torrential/Peers/PieceBufferManager.cs
@@ -1,0 +1,38 @@
+using System.Collections.Concurrent;
+
+namespace Torrential.Peers;
+
+public sealed class PieceBufferManager
+{
+    private readonly ConcurrentDictionary<(InfoHash, int pieceIndex), PieceBuffer> _buffers = new();
+
+    public PieceBuffer GetOrCreateBuffer(InfoHash infoHash, int pieceIndex, int pieceLength, PeerId owner)
+    {
+        var buffer = _buffers.GetOrAdd((infoHash, pieceIndex), _ => new PieceBuffer(pieceIndex, pieceLength, owner));
+
+        if (buffer.Owner != owner)
+            buffer.Reassign(owner);
+
+        return buffer;
+    }
+
+    public bool TryGetBuffer(InfoHash infoHash, int pieceIndex, out PieceBuffer? buffer)
+    {
+        return _buffers.TryGetValue((infoHash, pieceIndex), out buffer);
+    }
+
+    public void RemoveBuffer(InfoHash infoHash, int pieceIndex)
+    {
+        if (_buffers.TryRemove((infoHash, pieceIndex), out var buffer))
+            buffer.Dispose();
+    }
+
+    public void RemoveAllForTorrent(InfoHash infoHash)
+    {
+        foreach (var kvp in _buffers)
+        {
+            if (kvp.Key.Item1 == infoHash && _buffers.TryRemove(kvp.Key, out var buffer))
+                buffer.Dispose();
+        }
+    }
+}

--- a/src/Torrential/Peers/PieceSelector.cs
+++ b/src/Torrential/Peers/PieceSelector.cs
@@ -5,7 +5,7 @@ namespace Torrential.Peers
     public class PieceSelector(BitfieldManager bitfieldManager, PieceReservationService pieceReservationService, ILogger<PieceSelector> logger)
     {
         private const int RESERVATION_LENGTH_SECONDS = 30;
-        public async Task<PieceSuggestionResult> SuggestNextPieceAsync(InfoHash infohash, Bitfield peerBitfield)
+        public async Task<PieceSuggestionResult> SuggestNextPieceAsync(InfoHash infohash, Bitfield peerBitfield, PeerId peerId)
         {
             if (!bitfieldManager.TryGetVerificationBitfield(infohash, out var myBitfield))
                 return PieceSuggestionResult.NoMorePieces;
@@ -28,7 +28,7 @@ namespace Torrential.Peers
             if (myBitfield.CompletionRatio > 0.80)
                 reservationLengthSeconds = (int)(RESERVATION_LENGTH_SECONDS - ((RESERVATION_LENGTH_SECONDS - 1) * myBitfield.CompletionRatio));
 
-            var reserved = await pieceReservationService.TryReservePiece(infohash, suggestedIndex, reservationLengthSeconds);
+            var reserved = pieceReservationService.TryReservePiece(infohash, suggestedIndex, peerId, reservationLengthSeconds);
             if (!reserved)
             {
                 logger.LogDebug("Piece already reserved - {Index}", suggestedIndex);

--- a/src/Torrential/Peers/PooledBlock.cs
+++ b/src/Torrential/Peers/PooledBlock.cs
@@ -12,8 +12,9 @@ public sealed class PooledBlock : IDisposable
     public InfoHash InfoHash { get; private set; }
     public int PieceIndex { get; private set; }
     public int Offset { get; private set; }
+    public PeerId SenderPeerId { get; private set; }
 
-    public static PooledBlock FromReadOnlySequence(ReadOnlySequence<byte> sequence, int chunkSize, InfoHash infoHash)
+    public static PooledBlock FromReadOnlySequence(ReadOnlySequence<byte> sequence, int chunkSize, InfoHash infoHash, PeerId senderPeerId)
     {
         var reader = new SequenceReader<byte>(sequence);
 
@@ -25,6 +26,7 @@ public sealed class PooledBlock : IDisposable
             throw new ArgumentException("Error reading piece block data");
 
         var block = new PooledBlock((int)blockSequence.Length, ArrayPool<byte>.Shared, infoHash, pieceIndex, pieceOffset);
+        block.SenderPeerId = senderPeerId;
         blockSequence.CopyTo(block._buffer);
         return block;
     }

--- a/src/Torrential/ServiceCollectionExtensions.cs
+++ b/src/Torrential/ServiceCollectionExtensions.cs
@@ -26,7 +26,8 @@ public static class ServiceCollectionExtensions
 
         services.AddSingleton<IFileHandleProvider, FileHandleProvider>();
         services.AddSingleton<IMetadataFileService, MetadataFileService>();
-        services.AddSingleton<IBlockSaveService, BlockSaveService>();
+        services.AddSingleton<IBlockSaveService, InMemoryBlockSaveService>();
+        services.AddSingleton<PieceBufferManager>();
         services.AddSingleton<PeerSwarm>();
         services.AddSingleton<TorrentRunner>();
         services.AddSingleton<TorrentTaskManager>();

--- a/src/Torrential/Torrents/TorrentRunner.cs
+++ b/src/Torrential/Torrents/TorrentRunner.cs
@@ -73,7 +73,7 @@ namespace Torrential.Torrents
             while (!peer.State.AmChoked && !stoppingToken.IsCancellationRequested && hasMorePieces)
             {
                 //Start asking for pieces, wait for us to get a piece back then ask for the next piece
-                var suggestion = await pieceSelector.SuggestNextPieceAsync(meta.InfoHash, peer.State.PeerBitfield);
+                var suggestion = await pieceSelector.SuggestNextPieceAsync(meta.InfoHash, peer.State.PeerBitfield, peer.PeerId);
                 if (!suggestion.Index.HasValue)
                 {
                     hasMorePieces = suggestion.MorePiecesAvailable;

--- a/src/Torrential/Torrents/TorrentTaskManager.cs
+++ b/src/Torrential/Torrents/TorrentTaskManager.cs
@@ -5,7 +5,7 @@ using Torrential.Utilities;
 
 namespace Torrential.Torrents
 {
-    public class TorrentTaskManager(TorrentMetadataCache metaCache, PeerSwarm swarms, IBus bus, BitfieldManager bitfieldManager)
+    public class TorrentTaskManager(TorrentMetadataCache metaCache, PeerSwarm swarms, IBus bus, BitfieldManager bitfieldManager, PieceBufferManager pieceBufferManager)
     {
         private ConcurrentDictionary<InfoHash, string> Torrents = [];
         private ConcurrentDictionary<InfoHash, Task> TorrentTasks = [];
@@ -96,6 +96,7 @@ namespace Torrential.Torrents
             while (torrentTask.InProgress())
                 await Task.Delay(500);
 
+            pieceBufferManager.RemoveAllForTorrent(infoHash);
             await bus.Publish(new TorrentStoppedEvent { InfoHash = infoHash });
 
             return new()
@@ -131,6 +132,7 @@ namespace Torrential.Torrents
             while (torrentTask.InProgress())
                 await Task.Delay(500);
 
+            pieceBufferManager.RemoveAllForTorrent(infoHash);
             await bus.Publish(new TorrentRemovedEvent { InfoHash = infoHash });
             return new() { InfoHash = infoHash, Success = true };
         }


### PR DESCRIPTION
## Summary

- Replace fire-and-forget reservation with peer-owned expiry-tracked reservations in a ConcurrentDictionary, thread PeerId through PieceSelector and TorrentRunner.
- Create PieceBuffer with ArrayPool-backed storage and SHA1.HashData Span-based verification, plus PieceBufferManager for per-torrent buffer lifecycle.
- Create InMemoryBlockSaveService that buffers blocks in PieceBuffer, verifies via SHA1.HashData Span API, and discards data. Add SenderPeerId to PooledBlock.
- Swap DI to use InMemoryBlockSaveService, register PieceBufferManager, add peer disconnect reservation cleanup and torrent stop buffer cleanup.
- Run dotnet build to verify all changes compile, fix any errors.

## What was done

### Phase 1
- [x] Refactor PieceReservationService for peer-owned reservations with expiry

### Phase 2
- [x] Create in-memory PieceBuffer with Span-based SHA1 verification
- [x] Create InMemoryBlockSaveService replacing disk-based BlockSaveService

### Phase 3
- [x] Wire up new services in DI and update TorrentRunner for cleanup
- [x] Build verification

## Diff stat

```
 src/Torrential/Files/InMemoryBlockSaveService.cs | 63 +++++++++++++++++++++++
 src/Torrential/Peers/BitfieldManager.cs          | 10 ----
 src/Torrential/Peers/PeerSwarm.cs                |  4 ++
 src/Torrential/Peers/PeerWireClient.cs           |  2 +-
 src/Torrential/Peers/PieceBuffer.cs              | 64 ++++++++++++++++++++++++
 src/Torrential/Peers/PieceBufferManager.cs       | 38 ++++++++++++++
 src/Torrential/Peers/PieceReservationService.cs  | 55 +++++++++++++++-----
 src/Torrential/Peers/PieceSelector.cs            |  4 +-
 src/Torrential/Peers/PooledBlock.cs              |  4 +-
 src/Torrential/ServiceCollectionExtensions.cs    |  3 +-
 src/Torrential/Torrents/TorrentRunner.cs         |  2 +-
 src/Torrential/Torrents/TorrentTaskManager.cs    |  4 +-
 12 files changed, 224 insertions(+), 29 deletions(-)
```

---
*Generated by Jarvis*
