### PR TITLE
feat: connect to peers

### DIFF
--- a/src/Torrential.Application/IPeerConnectionManager.cs
+++ b/src/Torrential.Application/IPeerConnectionManager.cs
@@ -1,0 +1,20 @@
+using Torrential.Core;
+
+namespace Torrential.Application;
+
+public interface IPeerConnectionManager
+{
+    IReadOnlyList<ConnectedPeer> GetConnectedPeers(InfoHash infoHash);
+    int GetConnectedPeerCount(InfoHash infoHash);
+}
+
+public sealed class ConnectedPeer
+{
+    public required PeerInfo PeerInfo { get; init; }
+    public required PeerId PeerId { get; init; }
+    public required InfoHash InfoHash { get; init; }
+    public Bitfield? Bitfield { get; set; }
+    public long BytesDownloaded { get; set; }
+    public long BytesUploaded { get; set; }
+    public DateTimeOffset ConnectedAt { get; init; }
+}

--- a/src/Torrential.Application/PeerConnectionService.cs
+++ b/src/Torrential.Application/PeerConnectionService.cs
@@ -1,0 +1,253 @@
+using System.Collections.Concurrent;
+using System.Net.Sockets;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using Torrential.Core;
+
+namespace Torrential.Application;
+
+public sealed class PeerConnectionService(
+    ITorrentManager torrentManager,
+    IPeerPool peerPool,
+    HandshakeService handshakeService,
+    ILogger<PeerConnectionService> logger,
+    ILogger<IPeerWireConnection> pwcLogger) : BackgroundService, IPeerConnectionManager
+{
+    private readonly PeerId _selfId = PeerId.New;
+    private readonly ConcurrentDictionary<InfoHash, ConcurrentDictionary<PeerInfo, ManagedPeerConnection>> _connections = new();
+    private readonly SemaphoreSlim _halfOpenSemaphore = new(50, 50);
+    private const int MaxPeersPerTorrent = 50;
+
+    public IReadOnlyList<ConnectedPeer> GetConnectedPeers(InfoHash infoHash)
+    {
+        if (!_connections.TryGetValue(infoHash, out var peers))
+            return [];
+
+        return peers.Values.Select(m => new ConnectedPeer
+        {
+            PeerInfo = m.PeerInfo,
+            PeerId = m.PeerId,
+            InfoHash = infoHash,
+            Bitfield = m.Client.State.PeerBitfield,
+            BytesDownloaded = m.Client.BytesDownloaded,
+            BytesUploaded = m.Client.BytesUploaded,
+            ConnectedAt = m.ConnectedAt
+        }).ToList();
+    }
+
+    public int GetConnectedPeerCount(InfoHash infoHash)
+    {
+        if (!_connections.TryGetValue(infoHash, out var peers))
+            return 0;
+
+        return peers.Count;
+    }
+
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        logger.LogInformation("PeerConnectionService started with PeerId: {PeerId}", _selfId.ToAsciiString());
+
+        while (!stoppingToken.IsCancellationRequested)
+        {
+            try
+            {
+                await ConnectToPeers(stoppingToken);
+            }
+            catch (OperationCanceledException) when (stoppingToken.IsCancellationRequested)
+            {
+                break;
+            }
+            catch (Exception ex)
+            {
+                logger.LogError(ex, "Unexpected error in PeerConnectionService loop");
+            }
+
+            await Task.Delay(TimeSpan.FromSeconds(5), stoppingToken);
+        }
+
+        await DisconnectAll();
+    }
+
+    private async Task ConnectToPeers(CancellationToken stoppingToken)
+    {
+        var activeTorrents = torrentManager.GetTorrentsByStatus(TorrentStatus.Downloading);
+        var activeSet = new HashSet<InfoHash>(activeTorrents);
+
+        // Clean up connections for torrents that are no longer downloading
+        foreach (var infoHash in _connections.Keys)
+        {
+            if (!activeSet.Contains(infoHash))
+            {
+                await DisconnectTorrent(infoHash);
+            }
+        }
+
+        foreach (var infoHash in activeTorrents)
+        {
+            // Clean up completed/faulted connections
+            CleanupDisconnectedPeers(infoHash);
+
+            var torrentState = torrentManager.GetState(infoHash);
+            if (torrentState is null)
+                continue;
+
+            var torrentPeers = _connections.GetOrAdd(infoHash, _ => new ConcurrentDictionary<PeerInfo, ManagedPeerConnection>());
+            if (torrentPeers.Count >= MaxPeersPerTorrent)
+                continue;
+
+            var discoveredPeers = peerPool.GetPeers(infoHash);
+            foreach (var discovered in discoveredPeers)
+            {
+                if (stoppingToken.IsCancellationRequested)
+                    return;
+
+                if (torrentPeers.Count >= MaxPeersPerTorrent)
+                    break;
+
+                if (torrentPeers.ContainsKey(discovered.PeerInfo))
+                    continue;
+
+                var peerInfo = discovered.PeerInfo;
+                var numberOfPieces = torrentState.NumberOfPieces;
+
+                _ = Task.Run(async () =>
+                {
+                    await ConnectToPeer(infoHash, peerInfo, numberOfPieces, stoppingToken);
+                }, stoppingToken);
+            }
+        }
+    }
+
+    private async Task ConnectToPeer(InfoHash infoHash, PeerInfo peerInfo, int numberOfPieces, CancellationToken stoppingToken)
+    {
+        if (!await _halfOpenSemaphore.WaitAsync(0, stoppingToken))
+            return;
+
+        try
+        {
+            // Double-check we haven't already connected
+            if (_connections.TryGetValue(infoHash, out var peers) && peers.ContainsKey(peerInfo))
+                return;
+
+            var socket = new Socket(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp);
+            try
+            {
+                using var connectCts = CancellationTokenSource.CreateLinkedTokenSource(stoppingToken);
+                connectCts.CancelAfter(5_000);
+
+                await socket.ConnectAsync(peerInfo.Ip, peerInfo.Port, connectCts.Token);
+            }
+            catch (Exception ex)
+            {
+                socket.Dispose();
+                logger.LogDebug("Failed to connect to peer {Ip}:{Port} - {Error}", peerInfo.Ip, peerInfo.Port, ex.Message);
+                return;
+            }
+
+            var connection = new PeerWireSocketConnection(socket, pwcLogger);
+            try
+            {
+                using var handshakeCts = CancellationTokenSource.CreateLinkedTokenSource(stoppingToken);
+                handshakeCts.CancelAfter(5_000);
+
+                var response = await handshakeService.HandleOutbound(
+                    connection.Writer,
+                    connection.Reader,
+                    infoHash,
+                    _selfId,
+                    handshakeCts.Token);
+
+                if (!response.Success)
+                {
+                    logger.LogDebug("Handshake failed with peer {Ip}:{Port} - {Error}", peerInfo.Ip, peerInfo.Port, response.Error);
+                    await connection.DisposeAsync();
+                    return;
+                }
+
+                connection.SetInfoHash(infoHash);
+                connection.SetPeerId(response.PeerId);
+
+                var client = new PeerWireClient(connection, numberOfPieces, pwcLogger, stoppingToken);
+                var processTask = Task.Run(() => client.ProcessMessages(), stoppingToken);
+
+                var managed = new ManagedPeerConnection(client, connection, processTask, peerInfo, response.PeerId, DateTimeOffset.UtcNow);
+
+                var torrentPeers = _connections.GetOrAdd(infoHash, _ => new ConcurrentDictionary<PeerInfo, ManagedPeerConnection>());
+                if (!torrentPeers.TryAdd(peerInfo, managed))
+                {
+                    // Another task already connected to this peer
+                    await client.DisposeAsync();
+                    return;
+                }
+
+                logger.LogInformation("Connected to peer {Ip}:{Port} for torrent {InfoHash} (PeerId: {PeerId})",
+                    peerInfo.Ip, peerInfo.Port, infoHash.AsString(), response.PeerId.ToAsciiString());
+            }
+            catch (Exception ex)
+            {
+                logger.LogDebug("Error during handshake with {Ip}:{Port} - {Error}", peerInfo.Ip, peerInfo.Port, ex.Message);
+                await connection.DisposeAsync();
+            }
+        }
+        finally
+        {
+            _halfOpenSemaphore.Release();
+        }
+    }
+
+    private void CleanupDisconnectedPeers(InfoHash infoHash)
+    {
+        if (!_connections.TryGetValue(infoHash, out var peers))
+            return;
+
+        foreach (var (peerInfo, managed) in peers)
+        {
+            if (managed.ProcessTask.IsCompleted)
+            {
+                if (peers.TryRemove(peerInfo, out var removed))
+                {
+                    logger.LogInformation("Peer {Ip}:{Port} disconnected from torrent {InfoHash}",
+                        peerInfo.Ip, peerInfo.Port, infoHash.AsString());
+
+                    _ = Task.Run(async () =>
+                    {
+                        try { await removed.Client.DisposeAsync(); }
+                        catch { /* already cleaned up */ }
+                    });
+                }
+            }
+        }
+    }
+
+    private async Task DisconnectTorrent(InfoHash infoHash)
+    {
+        if (!_connections.TryRemove(infoHash, out var peers))
+            return;
+
+        logger.LogInformation("Disconnecting all peers for torrent {InfoHash}", infoHash.AsString());
+
+        foreach (var (_, managed) in peers)
+        {
+            try { await managed.Client.DisposeAsync(); }
+            catch { /* best effort */ }
+        }
+
+        peers.Clear();
+    }
+
+    private async Task DisconnectAll()
+    {
+        foreach (var infoHash in _connections.Keys.ToList())
+        {
+            await DisconnectTorrent(infoHash);
+        }
+    }
+
+    private sealed record ManagedPeerConnection(
+        PeerWireClient Client,
+        PeerWireSocketConnection Connection,
+        Task ProcessTask,
+        PeerInfo PeerInfo,
+        PeerId PeerId,
+        DateTimeOffset ConnectedAt);
+}

--- a/src/Torrential.Application/ServiceCollectionExtensions.cs
+++ b/src/Torrential.Application/ServiceCollectionExtensions.cs
@@ -24,6 +24,9 @@ public static class ServiceCollectionExtensions
         services.AddSingleton<IAnnounceService, AnnounceService>();
         services.AddSingleton<IPeerPool, PeerPool>();
         services.AddHostedService<TrackerAnnounceService>();
+        services.AddSingleton<PeerConnectionService>();
+        services.AddSingleton<IPeerConnectionManager>(sp => sp.GetRequiredService<PeerConnectionService>());
+        services.AddHostedService(sp => sp.GetRequiredService<PeerConnectionService>());
         return services;
     }
 }

--- a/src/torrential-frontend/src/components/torrent-info-pane.tsx
+++ b/src/torrential-frontend/src/components/torrent-info-pane.tsx
@@ -73,7 +73,7 @@ export function TorrentInfoPane({ infoHash }: TorrentInfoPaneProps) {
               activeTab === tab ? 'bg-accent text-accent-foreground' : 'text-muted-foreground hover:text-foreground'
             }`}
           >
-            {tab}{tab === 'peers' ? ` (${details.peers.length})` : ''}
+            {tab}{tab === 'peers' ? ` (${details.peers.length} / ${details.discoveredPeerCount} discovered)` : ''}
           </button>
         ))}
       </div>

--- a/src/torrential-frontend/src/lib/api/types.ts
+++ b/src/torrential-frontend/src/lib/api/types.ts
@@ -49,6 +49,7 @@ export interface TorrentDetails {
   pieces: boolean[];
   files: TorrentFileDetail[];
   peers: PeerDetail[];
+  discoveredPeerCount: number;
 }
 
 export interface TorrentFileDetail {

--- a/test/Torrential.Application.Tests/TorrentManagerTests.cs
+++ b/test/Torrential.Application.Tests/TorrentManagerTests.cs
@@ -1,5 +1,8 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging.Abstractions;
 using Torrential.Application;
+using Torrential.Application.Persistence;
 using Torrential.Core;
 using Xunit;
 
@@ -26,7 +29,15 @@ public class TorrentManagerTests
         PieceHashes = new byte[80]
     };
 
-    private static TorrentManager CreateManager() => new(NullLogger<TorrentManager>.Instance);
+    private static TorrentManager CreateManager()
+    {
+        var services = new ServiceCollection();
+        services.AddDbContext<TorrentDbContext>(options =>
+            options.UseInMemoryDatabase(databaseName: Guid.NewGuid().ToString()));
+        var serviceProvider = services.BuildServiceProvider();
+        var scopeFactory = serviceProvider.GetRequiredService<IServiceScopeFactory>();
+        return new TorrentManager(NullLogger<TorrentManager>.Instance, scopeFactory);
+    }
 
     // Add Tests
 

--- a/test/Torrential.Application.Tests/Torrential.Application.Tests.csproj
+++ b/test/Torrential.Application.Tests/Torrential.Application.Tests.csproj
@@ -10,6 +10,8 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="10.0.0" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
     <PackageReference Include="xunit" Version="2.9.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">


### PR DESCRIPTION
## Summary

- Build the core Application-layer service that manages outbound peer connections, performs handshakes, and runs PeerWireClient message loops to receive bitfields.
- Update the API's torrent details endpoint to return real connected peer data (PeerId, bitfield, progress, bytes transferred) from PeerConnectionManager instead of placeholder values from PeerPool.
- Update the frontend TypeScript types and peers list component to display real peer data and show the discovered peer count alongside connected peers.
- Ensure the full solution builds, unit tests pass, and E2E screenshots show correct UI.

## What was done

### Phase 1
- [x] Create PeerConnectionManager service

### Phase 2
- [x] Wire real peer data into API endpoint
- [x] Update frontend for real peer data and discovered count

### Phase 3
- [x] Build and verify end-to-end

## Diff stat

```
 src/Torrential.Api/Program.cs                      |  36 +--
 .../IPeerConnectionManager.cs                      |  20 ++
 .../PeerConnectionService.cs                       | 253 +++++++++++++++++++++
 .../ServiceCollectionExtensions.cs                 |   3 +
 .../src/components/torrent-info-pane.tsx           |   2 +-
 src/torrential-frontend/src/lib/api/types.ts       |   1 +
 .../TorrentManagerTests.cs                         |  13 +-
 .../Torrential.Application.Tests.csproj            |   2 +
 8 files changed, 312 insertions(+), 18 deletions(-)
```

---
*Generated by Jarvis*
