### PR TITLE
feat: Request and receive pieces

### DIFF
--- a/src/Torrential.Application/IPeerConnectionManager.cs
+++ b/src/Torrential.Application/IPeerConnectionManager.cs
@@ -6,6 +6,7 @@ public interface IPeerConnectionManager
 {
     IReadOnlyList<ConnectedPeer> GetConnectedPeers(InfoHash infoHash);
     int GetConnectedPeerCount(InfoHash infoHash);
+    PeerWireClient? GetPeerClient(InfoHash infoHash, PeerInfo peerInfo);
 }
 
 public sealed class ConnectedPeer

--- a/src/Torrential.Application/PeerConnectionService.cs
+++ b/src/Torrential.Application/PeerConnectionService.cs
@@ -43,6 +43,14 @@ public sealed class PeerConnectionService(
         return peers.Count;
     }
 
+    public PeerWireClient? GetPeerClient(InfoHash infoHash, PeerInfo peerInfo)
+    {
+        if (!_connections.TryGetValue(infoHash, out var peers))
+            return null;
+
+        return peers.TryGetValue(peerInfo, out var managed) ? managed.Client : null;
+    }
+
     protected override async Task ExecuteAsync(CancellationToken stoppingToken)
     {
         logger.LogInformation("PeerConnectionService started with PeerId: {PeerId}", _selfId.ToAsciiString());

--- a/src/Torrential.Application/PieceDownloadService.cs
+++ b/src/Torrential.Application/PieceDownloadService.cs
@@ -1,0 +1,198 @@
+using System.Collections.Concurrent;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using Torrential.Core;
+
+namespace Torrential.Application;
+
+public sealed class PieceDownloadService(
+    ITorrentManager torrentManager,
+    PeerConnectionService peerConnectionService,
+    ILogger<PieceDownloadService> logger) : BackgroundService
+{
+    private const int BlockSize = 16384;
+    private readonly ConcurrentDictionary<InfoHash, Bitfield> _localBitfields = new();
+    private readonly ConcurrentDictionary<(InfoHash, int), byte> _inFlightPieces = new();
+
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        logger.LogInformation("PieceDownloadService started");
+
+        while (!stoppingToken.IsCancellationRequested)
+        {
+            try
+            {
+                ProcessDownloads(stoppingToken);
+            }
+            catch (OperationCanceledException) when (stoppingToken.IsCancellationRequested)
+            {
+                break;
+            }
+            catch (Exception ex)
+            {
+                logger.LogError(ex, "Unexpected error in PieceDownloadService loop");
+            }
+
+            await Task.Delay(TimeSpan.FromSeconds(1), stoppingToken);
+        }
+
+        logger.LogInformation("PieceDownloadService stopped");
+    }
+
+    private void ProcessDownloads(CancellationToken stoppingToken)
+    {
+        var activeTorrents = torrentManager.GetTorrentsByStatus(TorrentStatus.Downloading);
+
+        foreach (var infoHash in activeTorrents)
+        {
+            var metaInfo = torrentManager.GetMetaInfo(infoHash);
+            if (metaInfo is null) continue;
+
+            var torrentState = torrentManager.GetState(infoHash);
+            if (torrentState is null) continue;
+
+            var localBitfield = _localBitfields.GetOrAdd(infoHash, _ => new Bitfield(torrentState.NumberOfPieces));
+            var connectedPeers = peerConnectionService.GetConnectedPeers(infoHash);
+
+            foreach (var peer in connectedPeers)
+            {
+                if (peer.Bitfield is null) continue;
+
+                var suggestion = localBitfield.SuggestPieceToDownload(peer.Bitfield);
+                if (suggestion.Index is null) continue;
+
+                var pieceIndex = suggestion.Index.Value;
+
+                // Skip if this piece is already being downloaded
+                if (!_inFlightPieces.TryAdd((infoHash, pieceIndex), 0))
+                    continue;
+
+                var client = peerConnectionService.GetPeerClient(infoHash, peer.PeerInfo);
+                if (client is null)
+                {
+                    _inFlightPieces.TryRemove((infoHash, pieceIndex), out _);
+                    continue;
+                }
+
+                if (client.State.AmChoked)
+                {
+                    _inFlightPieces.TryRemove((infoHash, pieceIndex), out _);
+                    _ = SendInterestedAsync(client);
+                    continue;
+                }
+
+                var capturedPieceIndex = pieceIndex;
+                var capturedMetaInfo = metaInfo;
+                var capturedLocalBitfield = localBitfield;
+                var capturedInfoHash = infoHash;
+
+                _ = Task.Run(async () =>
+                {
+                    await DownloadPieceAsync(capturedInfoHash, capturedPieceIndex, capturedMetaInfo, capturedLocalBitfield, client, stoppingToken);
+                }, stoppingToken);
+            }
+        }
+    }
+
+    private static async Task SendInterestedAsync(PeerWireClient client)
+    {
+        try
+        {
+            await client.SendInterested();
+        }
+        catch
+        {
+            // Best effort — peer may be disconnected
+        }
+    }
+
+    private async Task DownloadPieceAsync(
+        InfoHash infoHash,
+        int pieceIndex,
+        TorrentMetaInfo metaInfo,
+        Bitfield localBitfield,
+        PeerWireClient client,
+        CancellationToken stoppingToken)
+    {
+        var pieceSize = (int)(pieceIndex == metaInfo.NumberOfPieces - 1
+            ? metaInfo.TotalSize - (long)pieceIndex * metaInfo.PieceSize
+            : metaInfo.PieceSize);
+
+        var assembler = new PieceAssembler(pieceIndex, pieceSize, BlockSize);
+        try
+        {
+            // Send request messages for all blocks in this piece
+            var numberOfBlocks = (pieceSize + BlockSize - 1) / BlockSize;
+            for (var i = 0; i < numberOfBlocks; i++)
+            {
+                var offset = i * BlockSize;
+                var blockLength = Math.Min(BlockSize, pieceSize - offset);
+                await client.SendPieceRequest(pieceIndex, offset, blockLength);
+            }
+
+            // Read blocks from the channel
+            while (!assembler.IsComplete)
+            {
+                if (stoppingToken.IsCancellationRequested)
+                    return;
+
+                if (!await client.InboundBlocks.WaitToReadAsync(stoppingToken))
+                    break; // Channel completed — peer disconnected
+
+                while (client.InboundBlocks.TryRead(out var block))
+                {
+                    if (block.PieceIndex != pieceIndex)
+                    {
+                        block.Dispose();
+                        continue;
+                    }
+
+                    if (!assembler.TryAddBlock(block))
+                    {
+                        block.Dispose();
+                        continue;
+                    }
+
+                    if (assembler.IsComplete)
+                        break;
+                }
+            }
+
+            if (!assembler.IsComplete)
+            {
+                logger.LogWarning("Piece {PieceIndex} download incomplete for torrent {InfoHash} — peer disconnected",
+                    pieceIndex, infoHash.AsString());
+                return;
+            }
+
+            using var assembled = assembler.Complete();
+
+            var expectedHash = metaInfo.PieceHashes.AsSpan(pieceIndex * 20, 20);
+            if (assembled.Verify(expectedHash))
+            {
+                localBitfield.MarkHave(pieceIndex);
+                logger.LogInformation("Piece {PieceIndex} verified successfully for torrent {InfoHash}",
+                    pieceIndex, infoHash.AsString());
+            }
+            else
+            {
+                logger.LogWarning("Piece {PieceIndex} failed hash verification for torrent {InfoHash}",
+                    pieceIndex, infoHash.AsString());
+            }
+        }
+        catch (OperationCanceledException) when (stoppingToken.IsCancellationRequested)
+        {
+            // Shutting down
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(ex, "Error downloading piece {PieceIndex} for torrent {InfoHash}",
+                pieceIndex, infoHash.AsString());
+        }
+        finally
+        {
+            assembler.Dispose();
+            _inFlightPieces.TryRemove((infoHash, pieceIndex), out _);
+        }
+    }
+}

--- a/src/Torrential.Application/ServiceCollectionExtensions.cs
+++ b/src/Torrential.Application/ServiceCollectionExtensions.cs
@@ -27,6 +27,7 @@ public static class ServiceCollectionExtensions
         services.AddSingleton<PeerConnectionService>();
         services.AddSingleton<IPeerConnectionManager>(sp => sp.GetRequiredService<PeerConnectionService>());
         services.AddHostedService(sp => sp.GetRequiredService<PeerConnectionService>());
+        services.AddHostedService<PieceDownloadService>();
         return services;
     }
 }

--- a/src/Torrential.Core/AssembledPiece.cs
+++ b/src/Torrential.Core/AssembledPiece.cs
@@ -1,0 +1,35 @@
+using System.Security.Cryptography;
+
+namespace Torrential.Core;
+
+public sealed class AssembledPiece : IDisposable
+{
+    private readonly PooledBlock[] _blocks;
+    private readonly int _pieceSize;
+
+    public int PieceIndex { get; }
+
+    public AssembledPiece(int pieceIndex, PooledBlock[] blocks, int pieceSize)
+    {
+        PieceIndex = pieceIndex;
+        _blocks = blocks;
+        _pieceSize = pieceSize;
+    }
+
+    public bool Verify(ReadOnlySpan<byte> expectedHash)
+    {
+        using var hasher = IncrementalHash.CreateHash(HashAlgorithmName.SHA1);
+        foreach (var block in _blocks)
+            hasher.AppendData(block.Buffer);
+
+        Span<byte> hash = stackalloc byte[20];
+        hasher.GetHashAndReset(hash);
+        return hash.SequenceEqual(expectedHash);
+    }
+
+    public void Dispose()
+    {
+        foreach (var block in _blocks)
+            block.Dispose();
+    }
+}

--- a/src/Torrential.Core/PieceAssembler.cs
+++ b/src/Torrential.Core/PieceAssembler.cs
@@ -1,0 +1,62 @@
+namespace Torrential.Core;
+
+public sealed class PieceAssembler : IDisposable
+{
+    private readonly int _pieceIndex;
+    private readonly int _pieceSize;
+    private readonly int _blockSize;
+    private readonly PooledBlock?[] _blocks;
+    private int _receivedCount;
+    private bool _completed;
+
+    public int ExpectedBlockCount { get; }
+    public bool IsComplete => _receivedCount == ExpectedBlockCount;
+
+    public PieceAssembler(int pieceIndex, int pieceSize, int blockSize = 16384)
+    {
+        _pieceIndex = pieceIndex;
+        _pieceSize = pieceSize;
+        _blockSize = blockSize;
+        ExpectedBlockCount = (pieceSize + blockSize - 1) / blockSize;
+        _blocks = new PooledBlock?[ExpectedBlockCount];
+    }
+
+    public bool TryAddBlock(PooledBlock block)
+    {
+        if (block.PieceIndex != _pieceIndex)
+            return false;
+
+        var slot = block.Offset / _blockSize;
+        if (slot < 0 || slot >= _blocks.Length)
+            return false;
+
+        if (_blocks[slot] is not null)
+            return false;
+
+        _blocks[slot] = block;
+        _receivedCount++;
+        return true;
+    }
+
+    public AssembledPiece Complete()
+    {
+        var blocks = new PooledBlock[ExpectedBlockCount];
+        for (var i = 0; i < ExpectedBlockCount; i++)
+            blocks[i] = _blocks[i]!;
+
+        _completed = true;
+        return new AssembledPiece(_pieceIndex, blocks, _pieceSize);
+    }
+
+    public void Dispose()
+    {
+        if (_completed)
+            return;
+
+        for (var i = 0; i < _blocks.Length; i++)
+        {
+            _blocks[i]?.Dispose();
+            _blocks[i] = null;
+        }
+    }
+}

--- a/test/Torrential.Core.Tests/PieceAssemblerTests.cs
+++ b/test/Torrential.Core.Tests/PieceAssemblerTests.cs
@@ -1,0 +1,176 @@
+using System.Buffers;
+using System.Buffers.Binary;
+using System.Security.Cryptography;
+using Torrential.Core;
+using Xunit;
+
+namespace Torrential.Core.Tests;
+
+public class PieceAssemblerTests
+{
+    private static readonly InfoHash TestInfoHash =
+        InfoHash.FromHexString("0102030405060708091011121314151617181920");
+
+    private static PooledBlock CreateBlock(int pieceIndex, int offset, byte[] data)
+    {
+        // PooledBlock.FromReadOnlySequence expects: 4-byte pieceIndex (BE) + 4-byte offset (BE) + data
+        var payload = new byte[8 + data.Length];
+        BinaryPrimitives.WriteInt32BigEndian(payload.AsSpan(0, 4), pieceIndex);
+        BinaryPrimitives.WriteInt32BigEndian(payload.AsSpan(4, 4), offset);
+        data.CopyTo(payload, 8);
+
+        var sequence = new ReadOnlySequence<byte>(payload);
+        return PooledBlock.FromReadOnlySequence(sequence, data.Length, TestInfoHash);
+    }
+
+    private static PooledBlock CreateBlock(int pieceIndex, int offset, int size, byte fill = 0x00)
+    {
+        var data = new byte[size];
+        Array.Fill(data, fill);
+        return CreateBlock(pieceIndex, offset, data);
+    }
+
+    [Fact]
+    public void TryAddBlock_AcceptsBlocksInOrder()
+    {
+        var assembler = new PieceAssembler(pieceIndex: 0, pieceSize: 49152);
+
+        Assert.True(assembler.TryAddBlock(CreateBlock(0, 0, 16384)));
+        Assert.True(assembler.TryAddBlock(CreateBlock(0, 16384, 16384)));
+        Assert.True(assembler.TryAddBlock(CreateBlock(0, 32768, 16384)));
+
+        Assert.True(assembler.IsComplete);
+        assembler.Complete().Dispose();
+    }
+
+    [Fact]
+    public void TryAddBlock_AcceptsBlocksOutOfOrder()
+    {
+        var assembler = new PieceAssembler(pieceIndex: 0, pieceSize: 49152);
+
+        Assert.True(assembler.TryAddBlock(CreateBlock(0, 32768, 16384)));
+        Assert.True(assembler.TryAddBlock(CreateBlock(0, 0, 16384)));
+        Assert.True(assembler.TryAddBlock(CreateBlock(0, 16384, 16384)));
+
+        Assert.True(assembler.IsComplete);
+        assembler.Complete().Dispose();
+    }
+
+    [Fact]
+    public void TryAddBlock_RejectsDuplicateOffset()
+    {
+        var assembler = new PieceAssembler(pieceIndex: 0, pieceSize: 49152);
+
+        Assert.True(assembler.TryAddBlock(CreateBlock(0, 0, 16384)));
+        Assert.False(assembler.TryAddBlock(CreateBlock(0, 0, 16384)));
+        Assert.False(assembler.IsComplete);
+
+        assembler.Dispose();
+    }
+
+    [Fact]
+    public void TryAddBlock_RejectsWrongPieceIndex()
+    {
+        var assembler = new PieceAssembler(pieceIndex: 5, pieceSize: 49152);
+
+        Assert.False(assembler.TryAddBlock(CreateBlock(3, 0, 16384)));
+        Assert.False(assembler.IsComplete);
+
+        assembler.Dispose();
+    }
+
+    [Fact]
+    public void Verify_CorrectHash_ReturnsTrue()
+    {
+        const int pieceSize = 49152;
+        var assembler = new PieceAssembler(pieceIndex: 0, pieceSize: pieceSize);
+
+        // All zeros — build the full piece data to compute the expected hash
+        var fullPiece = new byte[pieceSize];
+        var expectedHash = SHA1.HashData(fullPiece);
+
+        assembler.TryAddBlock(CreateBlock(0, 0, 16384));
+        assembler.TryAddBlock(CreateBlock(0, 16384, 16384));
+        assembler.TryAddBlock(CreateBlock(0, 32768, 16384));
+
+        using var piece = assembler.Complete();
+        Assert.True(piece.Verify(expectedHash));
+    }
+
+    [Fact]
+    public void Verify_IncorrectHash_ReturnsFalse()
+    {
+        const int pieceSize = 49152;
+        var assembler = new PieceAssembler(pieceIndex: 0, pieceSize: pieceSize);
+
+        assembler.TryAddBlock(CreateBlock(0, 0, 16384));
+        assembler.TryAddBlock(CreateBlock(0, 16384, 16384));
+        assembler.TryAddBlock(CreateBlock(0, 32768, 16384));
+
+        var wrongHash = new byte[20];
+        Array.Fill(wrongHash, (byte)0xFF);
+
+        using var piece = assembler.Complete();
+        Assert.False(piece.Verify(wrongHash));
+    }
+
+    [Fact]
+    public void Dispose_DisposesPartialBlocks()
+    {
+        var assembler = new PieceAssembler(pieceIndex: 0, pieceSize: 49152);
+
+        assembler.TryAddBlock(CreateBlock(0, 0, 16384));
+        assembler.TryAddBlock(CreateBlock(0, 16384, 16384));
+
+        // Dispose with partial blocks — should not throw
+        assembler.Dispose();
+    }
+
+    [Fact]
+    public void Dispose_AfterComplete_DoesNotDoubleDispose()
+    {
+        var assembler = new PieceAssembler(pieceIndex: 0, pieceSize: 49152);
+
+        assembler.TryAddBlock(CreateBlock(0, 0, 16384));
+        assembler.TryAddBlock(CreateBlock(0, 16384, 16384));
+        assembler.TryAddBlock(CreateBlock(0, 32768, 16384));
+
+        var piece = assembler.Complete();
+
+        // Assembler should skip disposal since ownership was transferred
+        assembler.Dispose();
+
+        // AssembledPiece owns the blocks now
+        piece.Dispose();
+    }
+
+    [Fact]
+    public void AssembledPiece_Dispose_DisposesAllBlocks()
+    {
+        var assembler = new PieceAssembler(pieceIndex: 0, pieceSize: 49152);
+
+        assembler.TryAddBlock(CreateBlock(0, 0, 16384));
+        assembler.TryAddBlock(CreateBlock(0, 16384, 16384));
+        assembler.TryAddBlock(CreateBlock(0, 32768, 16384));
+
+        var piece = assembler.Complete();
+        piece.Dispose();
+    }
+
+    [Fact]
+    public void LastPiece_SmallerSize()
+    {
+        // pieceSize = 40000 → 16384 + 16384 + 7232 = 3 blocks
+        const int pieceSize = 40000;
+        var assembler = new PieceAssembler(pieceIndex: 0, pieceSize: pieceSize);
+
+        Assert.Equal(3, assembler.ExpectedBlockCount);
+
+        Assert.True(assembler.TryAddBlock(CreateBlock(0, 0, 16384)));
+        Assert.True(assembler.TryAddBlock(CreateBlock(0, 16384, 16384)));
+        Assert.True(assembler.TryAddBlock(CreateBlock(0, 32768, 7232)));
+
+        Assert.True(assembler.IsComplete);
+        assembler.Complete().Dispose();
+    }
+}


### PR DESCRIPTION
## Summary

- Create PieceAssembler (with IDisposable for peer disconnect cleanup) and AssembledPiece (with SHA-1 verification) in Torrential.Core
- BackgroundService that orchestrates piece downloading with proper cleanup on peer disconnect. Also adds GetPeerClient to IPeerConnectionManager.
- Unit tests covering block assembly, completion detection, SHA-1 verification, duplicate handling, and disposal (peer disconnect cleanup)
- Build the solution and run all unit tests, fix any compilation or test failures

## What was done

### Phase 1
- [x] Add PieceAssembler and AssembledPiece to Core

### Phase 2
- [x] Create PieceDownloadService

### Phase 3
- [x] Add unit tests for PieceAssembler and AssembledPiece
- [x] Run tests and verify build

## Diff stat

```
 .../IPeerConnectionManager.cs                      |   1 +
 .../PeerConnectionService.cs                       |   8 +
 src/Torrential.Application/PieceDownloadService.cs | 198 +++++++++++++++++++++
 .../ServiceCollectionExtensions.cs                 |   1 +
 src/Torrential.Core/AssembledPiece.cs              |  35 ++++
 src/Torrential.Core/PieceAssembler.cs              |  62 +++++++
 test/Torrential.Core.Tests/PieceAssemblerTests.cs  | 176 ++++++++++++++++++
 7 files changed, 481 insertions(+)
```

---
*Generated by Jarvis*
