### PR TITLE
feat: Add a github workflow to build and push docker image

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,0 +1,57 @@
+name: Build and Publish Docker Image
+
+on:
+  push:
+    branches: [master]
+    tags: ["v*"]
+  pull_request:
+    branches: [master]
+  workflow_dispatch:
+
+env:
+  REGISTRY: ghcr.io
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract Docker metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ github.repository_owner }}/torrential
+          tags: |
+            type=ref,event=branch
+            type=sha
+            type=ref,event=tag
+            type=raw,value=latest,enable={{is_default_branch}}
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: src/Torrential.Web/Dockerfile
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/README.md
+++ b/README.md
@@ -38,3 +38,24 @@ BEPs:
       - [ ] Receive
 - [ ] BEP06 - Fast Extensions
 - [x] BEP15 - UDP Tracker Protocol
+
+## Docker
+
+The Docker image is published to GitHub Container Registry on every push to `master` and on version tags.
+
+**Image:** `ghcr.io/labanar/torrential`
+
+### Tags
+
+| Tag | Description |
+|---|---|
+| `latest` | Latest build from the `master` branch |
+| `sha-<short>` | Immutable tag tied to a specific commit SHA |
+| `v*` | Immutable tag matching a Git version tag (e.g. `v1.0.0`) |
+
+### Quick start
+
+```bash
+docker pull ghcr.io/labanar/torrential:latest
+docker run -p 8080:8080 -v torrential-data:/app/data ghcr.io/labanar/torrential:latest
+```


### PR DESCRIPTION
## Summary

- Add a new GitHub Actions workflow that builds from the existing Torrential.Web Dockerfile and pushes to GHCR using an image name that excludes `web`.
- Ensure push/login only happens in safe contexts and workflow behavior is correct for PRs and forks.
- Run quick verification that the workflow references valid paths and aligns with current docker build setup, then document how to consume the image.

## What was done

### Phase 1
- [x] Create Docker Publish Workflow For Torrential Image
- [x] Add Safety Conditions And Registry Push Rules

### Phase 2
- [x] Validate Workflow Against Current Repository Build Assumptions

## Diff stat

```
 .github/workflows/docker-publish.yml | 57 ++++++++++++++++++++++++++++++++++++
 README.md                            | 21 +++++++++++++
 2 files changed, 78 insertions(+)
```

---
*Generated by Jarvis*
