### PR TITLE
feat: Fix input widths on settings page

### DIFF
--- a/src/torrential-ui-vite/src/pages/settings/index.tsx
+++ b/src/torrential-ui-vite/src/pages/settings/index.tsx
@@ -177,10 +177,18 @@ function GeneralSettings() {
         <SectionHeader name="Files" />
 
         <RowComponent label="Download Path">
-          <FormInput fieldName="downloadPath" control={fileSettingsControl} />
+          <FormInput
+            fieldName="downloadPath"
+            control={fileSettingsControl}
+            className={styles.pathInput}
+          />
         </RowComponent>
         <RowComponent label="Completed Path">
-          <FormInput fieldName="completedPath" control={fileSettingsControl} />
+          <FormInput
+            fieldName="completedPath"
+            control={fileSettingsControl}
+            className={styles.pathInput}
+          />
         </RowComponent>
 
         <Separator />

--- a/src/torrential-ui-vite/src/pages/settings/settings.module.css
+++ b/src/torrential-ui-vite/src/pages/settings/settings.module.css
@@ -49,7 +49,7 @@
 }
 
 .pathInput {
-  width: min(100%, 42rem);
+  width: min(100%, 36rem);
 }
 
 .saveButton {

--- a/src/torrential-ui-vite/src/pages/settings/settings.module.css
+++ b/src/torrential-ui-vite/src/pages/settings/settings.module.css
@@ -48,6 +48,10 @@
   width: 10em;
 }
 
+.pathInput {
+  width: min(100%, 42rem);
+}
+
 .saveButton {
   position: absolute;
   bottom: 2rem;


### PR DESCRIPTION
## Summary

- Add a dedicated CSS class and hook it to Download Path and Completed Path inputs so they no longer stretch across the full remaining row width.
- Run existing frontend checks and verify the settings screenshot reflects constrained path field widths.

## What was done

### Phase 1
- [x] Apply max-width styling to file path inputs

### Phase 2
- [x] Validate UI behavior and guard against regressions

## Diff stat

```
 src/torrential-ui-vite/src/pages/settings/index.tsx          | 12 ++++++++++--
 .../src/pages/settings/settings.module.css                   |  4 ++++
 2 files changed, 14 insertions(+), 2 deletions(-)
```

---
*Generated by Jarvis*
