### PR TITLE
feat: Split info pane UX

### DIFF
--- a/src/torrential-ui-vite/src/pages/torrent/detail-pane.module.css
+++ b/src/torrential-ui-vite/src/pages/torrent/detail-pane.module.css
@@ -1,11 +1,10 @@
 .detailPane {
   display: flex;
   flex-direction: column;
-  min-height: 200px;
+  height: 100%;
+  min-height: 0;
   min-width: 0;
-  overflow: auto;
-  overflow-x: hidden;
-  border-top: 1px solid hsl(var(--border));
+  overflow: hidden;
 }
 
 .detailHeader {
@@ -18,6 +17,8 @@
   position: sticky;
   top: 0;
   z-index: 1;
+  background: hsl(var(--background));
+  border-bottom: 1px solid hsl(var(--border));
 }
 
 .detailHeaderTitle {
@@ -30,14 +31,37 @@
   white-space: nowrap;
 }
 
+.detailHeaderActions {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.detailCloseButton {
+  width: 2rem;
+  height: 2rem;
+  border: 1px solid hsl(var(--border));
+  border-radius: 6px;
+  background: transparent;
+  color: inherit;
+  cursor: pointer;
+}
+
+.detailCloseButton:hover,
+.detailCloseButton:focus-visible {
+  background: hsl(var(--muted));
+  outline: none;
+}
+
 .tabs {
   display: flex;
   flex-direction: row;
   gap: 0;
-  border-bottom: 1px solid hsl(var(--border));
   padding: 0 1.25em;
   overflow-x: auto;
   -webkit-overflow-scrolling: touch;
+  flex: 0 0 auto;
+  border-bottom: 1px solid hsl(var(--border));
 }
 
 .tab {
@@ -68,7 +92,8 @@
 }
 
 .tabContent {
-  flex: 1;
+  flex: 1 1 0%;
+  min-height: 0;
   min-width: 0;
   overflow: auto;
   padding: 0.75em 1.25em;

--- a/src/torrential-ui-vite/src/pages/torrent/detail-pane.tsx
+++ b/src/torrential-ui-vite/src/pages/torrent/detail-pane.tsx
@@ -1,7 +1,7 @@
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { Checkbox } from "@/components/ui/checkbox";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
-import { faCircleNotch, faSeedling } from "@fortawesome/free-solid-svg-icons";
+import { faCircleNotch, faSeedling, faXmark } from "@fortawesome/free-solid-svg-icons";
 import classNames from "classnames";
 import { useAppDispatch, useAppSelector } from "../../store";
 import {
@@ -15,7 +15,12 @@ import styles from "./detail-pane.module.css";
 
 type Tab = "peers" | "bitfield" | "files";
 
-export function DetailPane({ infoHash }: { infoHash: string }) {
+interface DetailPaneProps {
+  infoHash: string;
+  onClose: () => void;
+}
+
+export function DetailPane({ infoHash, onClose }: DetailPaneProps) {
   const dispatch = useAppDispatch();
   const { detail, loading, error } = useAppSelector((s) => s.torrentDetail);
   const [activeTab, setActiveTab] = useState<Tab>("peers");
@@ -100,6 +105,16 @@ export function DetailPane({ infoHash }: { infoHash: string }) {
     <div className={styles.detailPane}>
       <div className={styles.detailHeader}>
         <span className={styles.detailHeaderTitle}>{detail.name}</span>
+        <div className={styles.detailHeaderActions}>
+          <button
+            type="button"
+            className={styles.detailCloseButton}
+            aria-label="Close torrent details"
+            onClick={onClose}
+          >
+            <FontAwesomeIcon icon={faXmark} />
+          </button>
+        </div>
       </div>
       <div className={styles.tabs}>
         <TabButton label="PEERS" tab="peers" active={activeTab} onClick={setActiveTab} />

--- a/src/torrential-ui-vite/src/pages/torrent/torrent.module.css
+++ b/src/torrential-ui-vite/src/pages/torrent/torrent.module.css
@@ -20,10 +20,34 @@
 
 .bottomPane {
   flex: 0 0 auto;
-  max-height: 50%;
-  min-height: 200px;
-  overflow: auto;
-  overflow-x: hidden;
+  min-height: 0;
+  min-width: 0;
+  overflow: hidden;
+  border-top: 1px solid hsl(var(--border));
+}
+
+.splitPaneHandle {
+  flex: 0 0 auto;
+  height: 14px;
+  width: 100%;
+  cursor: ns-resize;
+  user-select: none;
+  touch-action: none;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: hsl(var(--muted-foreground));
+  border-top: 1px solid hsl(var(--border));
+  border-bottom: 1px solid hsl(var(--border));
+  background: hsl(var(--background));
+}
+
+.splitPaneHandle:hover,
+.splitPaneHandle:focus-visible,
+.splitPaneHandleActive {
+  color: hsl(var(--foreground));
+  background: hsl(var(--muted));
+  outline: none;
 }
 
 .torrentList {
@@ -376,9 +400,8 @@
 }
 
 @media (max-width: 768px) {
-  .bottomPane {
-    min-height: 220px;
-    max-height: 55%;
+  .splitPaneHandle {
+    height: 18px;
   }
 
   .actionBar {


### PR DESCRIPTION
## Summary

- Decouple row focus from detail pane visibility so users can close the pane without it immediately reopening on selection navigation.
- Make split pane height consistent across tab switches and provide clear controls to close/collapse it.
- Add automated UI checks that fail if the pane jumps in height by tab or cannot be closed.

## What was done

### Phase 1
- [x] Refactor detail pane open/close state from row focus
- [x] Implement stable split-pane sizing and close/collapse controls

### Phase 2
- [x] Add regression coverage for pane stability and closability

## Diff stat

```
 .../src/pages/torrent/detail-pane.module.css       |  37 ++++-
 .../src/pages/torrent/detail-pane.tsx              |  19 ++-
 src/torrential-ui-vite/src/pages/torrent/index.tsx | 177 +++++++++++++++++++--
 .../src/pages/torrent/torrent.module.css           |  37 ++++-
 test/Torrential.E2E/tests/screenshots.spec.ts      |  56 ++++++-
 5 files changed, 298 insertions(+), 28 deletions(-)
```

---
*Generated by Jarvis*
