### PR TITLE
feat: Torrent info pane file list has all items selected

### DIFF
--- a/src/Torrential/Commands/TorrentAddCommand.cs
+++ b/src/Torrential/Commands/TorrentAddCommand.cs
@@ -40,9 +40,9 @@ namespace Torrential.Commands
             //Save the metadata to the file system
             await metaFileService.SaveMetadata(command.Metadata);
 
-            // Default all files selected on add
-            var allFileIds = command.Metadata.Files.Select(f => f.Id).ToArray();
-            await fileSelectionService.SetSelectedFileIds(command.Metadata.InfoHash, allFileIds);
+            // Persist the effective file selection (respects user choice from the add dialog)
+            var selectedFileIds = command.Metadata.Files.Where(f => f.IsSelected).Select(f => f.Id).ToArray();
+            await fileSelectionService.SetSelectedFileIds(command.Metadata.InfoHash, selectedFileIds);
 
             await db.SaveChangesAsync();
             await mgr.Add(command.Metadata, recoveryResult);


### PR DESCRIPTION
## Summary

- Update add command flow so persisted file selection matches the IDs chosen in the add dialog instead of forcing all files selected.
- Add tests that fail on current behavior and pass once add-flow persistence is corrected.
- Ensure torrent detail file checkbox data still comes from persisted selection and reflects initial add selection after fix.

## What was done

### Phase 1
- [x] Persist actual selected file IDs during torrent add

### Phase 2
- [x] Add regression tests for add-flow selection persistence
- [x] Validate detail-pane contract remains correct

## Diff stat

```
 src/Torrential/Commands/TorrentAddCommand.cs       |   6 +-
 .../FileSelectionRegressionTests.cs                | 254 ++++++++++++++++++++-
 2 files changed, 248 insertions(+), 12 deletions(-)
```

---
*Generated by Jarvis*
