### PR TITLE
feat: Mock Integrations

### DIFF
--- a/src/Torrential.Web/Api/Requests/Integrations/IntegrationCreateRequest.cs
+++ b/src/Torrential.Web/Api/Requests/Integrations/IntegrationCreateRequest.cs
@@ -1,0 +1,19 @@
+namespace Torrential.Web.Api.Requests.Integrations;
+
+public class IntegrationCreateRequest
+{
+    public required string Name { get; set; }
+    public required string Type { get; set; } // "Slack", "Discord", "Exec"
+    public required string TriggerEvent { get; set; } // "torrent_complete", "torrent_added", etc.
+    public bool Enabled { get; set; } = true;
+    public string Configuration { get; set; } = "{}";
+}
+
+public class IntegrationUpdateRequest
+{
+    public required string Name { get; set; }
+    public required string Type { get; set; }
+    public required string TriggerEvent { get; set; }
+    public bool Enabled { get; set; }
+    public string Configuration { get; set; } = "{}";
+}

--- a/src/Torrential.Web/Api/Responses/Integrations/IntegrationResponses.cs
+++ b/src/Torrential.Web/Api/Responses/Integrations/IntegrationResponses.cs
@@ -1,0 +1,55 @@
+using System.Text.Json.Serialization;
+
+namespace Torrential.Web.Api.Responses.Integrations;
+
+public class IntegrationVm
+{
+    public Guid Id { get; set; }
+    public string Name { get; set; } = "";
+    public string Type { get; set; } = "";
+    public bool Enabled { get; set; }
+    public string TriggerEvent { get; set; } = "";
+    public string Configuration { get; set; } = "{}";
+}
+
+public class IntegrationListResponse : IDataResponse<IntegrationVm[]>, IErrorResponse
+{
+    public IntegrationVm[]? Data { get; private set; }
+    public ErrorData? Error { get; private set; }
+
+    [JsonConstructor]
+    private IntegrationListResponse(IntegrationVm[] data, ErrorData? error)
+    {
+        Data = data;
+        Error = error;
+    }
+
+    public IntegrationListResponse(IntegrationVm[] data)
+    {
+        Data = data;
+    }
+
+    public static IntegrationListResponse ErrorResponse(ErrorCode errorCode) =>
+        new([], new() { Code = errorCode });
+}
+
+public class IntegrationGetResponse : IDataResponse<IntegrationVm>, IErrorResponse
+{
+    public IntegrationVm? Data { get; private set; }
+    public ErrorData? Error { get; private set; }
+
+    [JsonConstructor]
+    private IntegrationGetResponse(IntegrationVm data, ErrorData? error)
+    {
+        Data = data;
+        Error = error;
+    }
+
+    public IntegrationGetResponse(IntegrationVm data)
+    {
+        Data = data;
+    }
+
+    public static IntegrationGetResponse ErrorResponse(ErrorCode errorCode) =>
+        new(null!, new() { Code = errorCode });
+}

--- a/src/Torrential/Integrations/Integration.cs
+++ b/src/Torrential/Integrations/Integration.cs
@@ -1,0 +1,18 @@
+namespace Torrential.Integrations;
+
+public class Integration
+{
+    public Guid Id { get; set; } = Guid.NewGuid();
+    public required string Name { get; set; }
+    public IntegrationType Type { get; set; }
+    public bool Enabled { get; set; } = true;
+    public required string TriggerEvent { get; set; } // e.g. "torrent_complete", "torrent_added", "torrent_started", "torrent_stopped"
+    public string Configuration { get; set; } = "{}"; // JSON blob for type-specific config
+}
+
+public enum IntegrationType
+{
+    Slack,
+    Discord,
+    Exec
+}

--- a/src/Torrential/Integrations/IntegrationExecutor.cs
+++ b/src/Torrential/Integrations/IntegrationExecutor.cs
@@ -1,0 +1,23 @@
+using Microsoft.Extensions.Logging;
+using Torrential.Torrents;
+
+namespace Torrential.Integrations;
+
+public sealed class IntegrationExecutor(IntegrationService integrationService, ILogger<IntegrationExecutor> logger)
+{
+    public async Task HandleTorrentComplete(TorrentCompleteEvent evt) => await ExecuteIntegrations("torrent_complete", evt.InfoHash);
+    public async Task HandleTorrentAdded(TorrentAddedEvent evt) => await ExecuteIntegrations("torrent_added", evt.InfoHash);
+    public async Task HandleTorrentStarted(TorrentStartedEvent evt) => await ExecuteIntegrations("torrent_started", evt.InfoHash);
+    public async Task HandleTorrentStopped(TorrentStoppedEvent evt) => await ExecuteIntegrations("torrent_stopped", evt.InfoHash);
+
+    private async Task ExecuteIntegrations(string triggerEvent, InfoHash infoHash)
+    {
+        var integrations = await integrationService.GetEnabledByTrigger(triggerEvent);
+        foreach (var integration in integrations)
+        {
+            logger.LogInformation("[Mock] Executing {Type} integration '{Name}' for {Event} on {InfoHash}",
+                integration.Type, integration.Name, triggerEvent, infoHash);
+            // Mock execution - just log. Real implementation would send webhooks or exec commands.
+        }
+    }
+}

--- a/src/Torrential/Integrations/IntegrationService.cs
+++ b/src/Torrential/Integrations/IntegrationService.cs
@@ -1,0 +1,66 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Torrential.Settings;
+
+namespace Torrential.Integrations;
+
+public sealed class IntegrationService(IServiceScopeFactory serviceScopeFactory)
+{
+    public async Task<List<Integration>> GetAll()
+    {
+        using var lease = new ScopedDbContextLease<TorrentialDb>(serviceScopeFactory);
+        return await lease.Context.Integrations.AsNoTracking().ToListAsync();
+    }
+
+    public async Task<Integration?> GetById(Guid id)
+    {
+        using var lease = new ScopedDbContextLease<TorrentialDb>(serviceScopeFactory);
+        return await lease.Context.Integrations.AsNoTracking().FirstOrDefaultAsync(x => x.Id == id);
+    }
+
+    public async Task<Integration> Create(Integration integration)
+    {
+        using var lease = new ScopedDbContextLease<TorrentialDb>(serviceScopeFactory);
+        await lease.Context.Integrations.AddAsync(integration);
+        await lease.Context.SaveChangesAsync();
+        return integration;
+    }
+
+    public async Task<Integration?> Update(Guid id, Integration updated)
+    {
+        using var lease = new ScopedDbContextLease<TorrentialDb>(serviceScopeFactory);
+        var existing = await lease.Context.Integrations.FirstOrDefaultAsync(x => x.Id == id);
+        if (existing is null)
+            return null;
+
+        existing.Name = updated.Name;
+        existing.Type = updated.Type;
+        existing.Enabled = updated.Enabled;
+        existing.TriggerEvent = updated.TriggerEvent;
+        existing.Configuration = updated.Configuration;
+
+        await lease.Context.SaveChangesAsync();
+        return existing;
+    }
+
+    public async Task<bool> Delete(Guid id)
+    {
+        using var lease = new ScopedDbContextLease<TorrentialDb>(serviceScopeFactory);
+        var existing = await lease.Context.Integrations.FirstOrDefaultAsync(x => x.Id == id);
+        if (existing is null)
+            return false;
+
+        lease.Context.Integrations.Remove(existing);
+        await lease.Context.SaveChangesAsync();
+        return true;
+    }
+
+    public async Task<List<Integration>> GetEnabledByTrigger(string triggerEvent)
+    {
+        using var lease = new ScopedDbContextLease<TorrentialDb>(serviceScopeFactory);
+        return await lease.Context.Integrations
+            .AsNoTracking()
+            .Where(x => x.Enabled && x.TriggerEvent == triggerEvent)
+            .ToListAsync();
+    }
+}

--- a/src/Torrential/Migrations/20260221140535_AddIntegrations.Designer.cs
+++ b/src/Torrential/Migrations/20260221140535_AddIntegrations.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using System.Collections.Generic;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Torrential;
 
@@ -11,9 +12,11 @@ using Torrential;
 namespace Torrential.Migrations
 {
     [DbContext(typeof(TorrentialDb))]
-    partial class TorrentialDbModelSnapshot : ModelSnapshot
+    [Migration("20260221140535_AddIntegrations")]
+    partial class AddIntegrations
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder.HasAnnotation("ProductVersion", "8.0.1");

--- a/src/Torrential/Migrations/20260221140535_AddIntegrations.cs
+++ b/src/Torrential/Migrations/20260221140535_AddIntegrations.cs
@@ -1,0 +1,38 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Torrential.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddIntegrations : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "Integrations",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "TEXT", nullable: false),
+                    Name = table.Column<string>(type: "TEXT", nullable: false),
+                    Type = table.Column<string>(type: "TEXT", nullable: false),
+                    Enabled = table.Column<bool>(type: "INTEGER", nullable: false),
+                    TriggerEvent = table.Column<string>(type: "TEXT", nullable: false),
+                    Configuration = table.Column<string>(type: "TEXT", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_Integrations", x => x.Id);
+                });
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "Integrations");
+        }
+    }
+}

--- a/src/Torrential/ServiceCollectionExtensions.cs
+++ b/src/Torrential/ServiceCollectionExtensions.cs
@@ -2,6 +2,7 @@ using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
 using Torrential.Commands;
 using Torrential.Files;
+using Torrential.Integrations;
 using Torrential.Peers;
 using Torrential.Pipelines;
 using Torrential.Settings;
@@ -57,6 +58,8 @@ public static class ServiceCollectionExtensions
         services.AddSingleton<TorrentStatusCacheMaintainer>();
         services.AddSingleton<AnnounceServiceEventHandler>();
         services.AddSingleton<PostDownloadActionExecutor>();
+        services.AddSingleton<IntegrationService>();
+        services.AddSingleton<IntegrationExecutor>();
 
         //TODO - add service extension that scans the provided assemblies for implementations of ICommandHandler<,>
         services.AddCommandHandler<TorrentAddCommand, TorrentAddResponse, TorrentAddCommandHandler>();

--- a/src/Torrential/TorrentialDb.cs
+++ b/src/Torrential/TorrentialDb.cs
@@ -1,5 +1,6 @@
 ﻿using Microsoft.EntityFrameworkCore;
 using Torrential.Files;
+using Torrential.Integrations;
 
 namespace Torrential
 {
@@ -7,6 +8,7 @@ namespace Torrential
     {
         public DbSet<TorrentConfiguration> Torrents { get; set; }
         public DbSet<TorrentialSettings> Settings { get; set; }
+        public DbSet<Integration> Integrations { get; set; }
         public TorrentialDb(DbContextOptions<TorrentialDb> options) : base(options)
         {
 
@@ -23,6 +25,15 @@ namespace Torrential
                 .HasConversion(
                     v => v.ToString(),
                     v => (TorrentStatus)Enum.Parse(typeof(TorrentStatus), v));
+
+            modelBuilder.Entity<Integration>()
+                .HasKey(x => x.Id);
+
+            modelBuilder.Entity<Integration>()
+                .Property(p => p.Type)
+                .HasConversion(
+                    v => v.ToString(),
+                    v => (IntegrationType)Enum.Parse(typeof(IntegrationType), v));
 
             modelBuilder.Entity<TorrentialSettings>()
                 .ComplexProperty(p => p.FileSettings);

--- a/src/torrential-ui-vite/src/pages/integrations/index.tsx
+++ b/src/torrential-ui-vite/src/pages/integrations/index.tsx
@@ -1,9 +1,352 @@
+import { faHashtag, faGamepad, faTerminal, faPlus, faPen, faTrash } from "@fortawesome/free-solid-svg-icons";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import { useCallback, useEffect, useState } from "react";
+import { useForm, Controller } from "react-hook-form";
+import styles from "./integrations.module.css";
+import { FormInput } from "../../components/Form/FormInput";
+import { FormCheckbox } from "../../components/Form/FormCheckbox";
+import { Separator } from "@/components/ui/separator";
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogFooter,
+  DialogDescription,
+} from "@/components/ui/dialog";
 import Layout from "../layout";
+import {
+  type IntegrationApiModel,
+  fetchIntegrations,
+  createIntegration,
+  updateIntegration,
+  deleteIntegration,
+} from "../../services/api";
+
+const INTEGRATION_TYPES = [
+  { value: "Slack", label: "Slack", icon: faHashtag },
+  { value: "Discord", label: "Discord", icon: faGamepad },
+  { value: "Exec", label: "Exec", icon: faTerminal },
+] as const;
+
+const TRIGGER_EVENTS = [
+  { value: "torrent_complete", label: "Download Complete" },
+  { value: "torrent_added", label: "Torrent Added" },
+  { value: "torrent_started", label: "Torrent Started" },
+  { value: "torrent_stopped", label: "Torrent Stopped" },
+] as const;
+
+function getTypeIcon(type: string) {
+  const found = INTEGRATION_TYPES.find((t) => t.value === type);
+  return found?.icon ?? faHashtag;
+}
+
+function getTriggerEventLabel(event: string) {
+  const found = TRIGGER_EVENTS.find((e) => e.value === event);
+  return found?.label ?? event;
+}
+
+interface IntegrationFormValues {
+  name: string;
+  type: string;
+  triggerEvent: string;
+  enabled: boolean;
+  webhookUrl: string;
+  command: string;
+}
+
+function serializeConfiguration(type: string, values: IntegrationFormValues): string {
+  if (type === "Slack" || type === "Discord") {
+    return JSON.stringify({ webhookUrl: values.webhookUrl });
+  }
+  if (type === "Exec") {
+    return JSON.stringify({ command: values.command });
+  }
+  return "{}";
+}
+
+function parseConfiguration(type: string, configJson: string): { webhookUrl: string; command: string } {
+  try {
+    const parsed = JSON.parse(configJson);
+    if (type === "Slack" || type === "Discord") {
+      return { webhookUrl: parsed.webhookUrl ?? "", command: "" };
+    }
+    if (type === "Exec") {
+      return { webhookUrl: "", command: parsed.command ?? "" };
+    }
+  } catch {
+    // ignore parse errors
+  }
+  return { webhookUrl: "", command: "" };
+}
+
+const DEFAULT_FORM_VALUES: IntegrationFormValues = {
+  name: "",
+  type: "Slack",
+  triggerEvent: "torrent_complete",
+  enabled: true,
+  webhookUrl: "",
+  command: "",
+};
 
 export default function IntegrationsPage() {
   return (
     <Layout>
-      <div>Hi from integrations</div>
+      <IntegrationsContent />
     </Layout>
+  );
+}
+
+function IntegrationsContent() {
+  const [integrations, setIntegrations] = useState<IntegrationApiModel[]>([]);
+  const [dialogOpen, setDialogOpen] = useState(false);
+  const [editingId, setEditingId] = useState<string | null>(null);
+
+  const { control, handleSubmit, reset, watch } = useForm<IntegrationFormValues>({
+    defaultValues: DEFAULT_FORM_VALUES,
+  });
+
+  const selectedType = watch("type");
+
+  const loadIntegrations = useCallback(async () => {
+    try {
+      const data = await fetchIntegrations();
+      setIntegrations(data);
+    } catch (error) {
+      console.error("Failed to fetch integrations", error);
+    }
+  }, []);
+
+  useEffect(() => {
+    loadIntegrations();
+  }, [loadIntegrations]);
+
+  const openAddDialog = useCallback(() => {
+    setEditingId(null);
+    reset(DEFAULT_FORM_VALUES);
+    setDialogOpen(true);
+  }, [reset]);
+
+  const openEditDialog = useCallback(
+    (integration: IntegrationApiModel) => {
+      setEditingId(integration.id);
+      const config = parseConfiguration(integration.type, integration.configuration);
+      reset({
+        name: integration.name,
+        type: integration.type,
+        triggerEvent: integration.triggerEvent,
+        enabled: integration.enabled,
+        webhookUrl: config.webhookUrl,
+        command: config.command,
+      });
+      setDialogOpen(true);
+    },
+    [reset]
+  );
+
+  const onSubmit = useCallback(
+    async (values: IntegrationFormValues) => {
+      const payload = {
+        name: values.name,
+        type: values.type,
+        triggerEvent: values.triggerEvent,
+        enabled: values.enabled,
+        configuration: serializeConfiguration(values.type, values),
+      };
+      try {
+        if (editingId) {
+          await updateIntegration(editingId, payload);
+        } else {
+          await createIntegration(payload);
+        }
+        setDialogOpen(false);
+        loadIntegrations();
+      } catch (error) {
+        console.error("Failed to save integration", error);
+      }
+    },
+    [editingId, loadIntegrations]
+  );
+
+  const handleDelete = useCallback(
+    async (id: string) => {
+      try {
+        await deleteIntegration(id);
+        loadIntegrations();
+      } catch (error) {
+        console.error("Failed to delete integration", error);
+      }
+    },
+    [loadIntegrations]
+  );
+
+  const handleToggleEnabled = useCallback(
+    async (integration: IntegrationApiModel) => {
+      try {
+        await updateIntegration(integration.id, {
+          name: integration.name,
+          type: integration.type,
+          triggerEvent: integration.triggerEvent,
+          enabled: !integration.enabled,
+          configuration: integration.configuration,
+        });
+        loadIntegrations();
+      } catch (error) {
+        console.error("Failed to toggle integration", error);
+      }
+    },
+    [loadIntegrations]
+  );
+
+  return (
+    <div className={`${styles.integrationsRoot} page-shell`}>
+      <div className={styles.pageHeader}>
+        <h1 className={styles.pageTitle}>Integrations</h1>
+        <Button className={styles.addButton} onClick={openAddDialog} type="button">
+          <FontAwesomeIcon icon={faPlus} />
+          <span className={styles.addButtonLabel}>Add Integration</span>
+        </Button>
+      </div>
+      <Separator />
+
+      {integrations.length === 0 ? (
+        <div className={styles.emptyState}>
+          <p>No integrations configured.</p>
+        </div>
+      ) : (
+        <div className={styles.integrationsList}>
+          {integrations.map((integration) => (
+            <div key={integration.id} className={styles.integrationCard}>
+              <div className={styles.integrationIcon}>
+                <FontAwesomeIcon icon={getTypeIcon(integration.type)} />
+              </div>
+              <div className={styles.integrationInfo}>
+                <p className={styles.integrationName}>{integration.name}</p>
+                <p className={styles.integrationMeta}>
+                  {integration.type} &middot; {getTriggerEventLabel(integration.triggerEvent)}
+                  {!integration.enabled && " \u00B7 Disabled"}
+                </p>
+              </div>
+              <div className={styles.integrationActions}>
+                <Button
+                  variant="ghost"
+                  size="icon"
+                  onClick={() => handleToggleEnabled(integration)}
+                  aria-label={integration.enabled ? "Disable integration" : "Enable integration"}
+                  style={{ opacity: integration.enabled ? 1 : 0.5 }}
+                >
+                  <span
+                    style={{
+                      width: "2rem",
+                      height: "1.15rem",
+                      borderRadius: "999px",
+                      background: integration.enabled
+                        ? "hsl(var(--primary))"
+                        : "hsl(var(--muted))",
+                      position: "relative",
+                      display: "inline-block",
+                      transition: "background 0.2s",
+                    }}
+                  >
+                    <span
+                      style={{
+                        position: "absolute",
+                        top: "0.1rem",
+                        left: integration.enabled ? "calc(100% - 1.05rem)" : "0.1rem",
+                        width: "0.95rem",
+                        height: "0.95rem",
+                        borderRadius: "50%",
+                        background: "hsl(var(--background))",
+                        transition: "left 0.2s",
+                      }}
+                    />
+                  </span>
+                </Button>
+                <Button variant="ghost" size="icon" onClick={() => openEditDialog(integration)} aria-label="Edit integration">
+                  <FontAwesomeIcon icon={faPen} />
+                </Button>
+                <Button variant="ghost" size="icon" onClick={() => handleDelete(integration.id)} aria-label="Delete integration">
+                  <FontAwesomeIcon icon={faTrash} />
+                </Button>
+              </div>
+            </div>
+          ))}
+        </div>
+      )}
+
+      <Dialog open={dialogOpen} onOpenChange={setDialogOpen}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>{editingId ? "Edit Integration" : "Add Integration"}</DialogTitle>
+            <DialogDescription>
+              {editingId
+                ? "Update the integration settings below."
+                : "Configure a new integration to respond to torrent events."}
+            </DialogDescription>
+          </DialogHeader>
+          <form onSubmit={handleSubmit(onSubmit)} className={styles.dialogForm}>
+            <div className={styles.formField}>
+              <label className={styles.formLabel}>Name</label>
+              <FormInput fieldName="name" control={control} />
+            </div>
+
+            <div className={styles.formField}>
+              <label className={styles.formLabel}>Type</label>
+              <Controller
+                name="type"
+                control={control}
+                render={({ field }) => (
+                  <select {...field} className={styles.formSelect}>
+                    {INTEGRATION_TYPES.map((t) => (
+                      <option key={t.value} value={t.value}>
+                        {t.label}
+                      </option>
+                    ))}
+                  </select>
+                )}
+              />
+            </div>
+
+            <div className={styles.formField}>
+              <label className={styles.formLabel}>Trigger Event</label>
+              <Controller
+                name="triggerEvent"
+                control={control}
+                render={({ field }) => (
+                  <select {...field} className={styles.formSelect}>
+                    {TRIGGER_EVENTS.map((e) => (
+                      <option key={e.value} value={e.value}>
+                        {e.label}
+                      </option>
+                    ))}
+                  </select>
+                )}
+              />
+            </div>
+
+            <FormCheckbox control={control} fieldName="enabled" text="Enabled" />
+
+            {(selectedType === "Slack" || selectedType === "Discord") && (
+              <div className={styles.formField}>
+                <label className={styles.formLabel}>Webhook URL</label>
+                <FormInput fieldName="webhookUrl" control={control} />
+              </div>
+            )}
+
+            {selectedType === "Exec" && (
+              <div className={styles.formField}>
+                <label className={styles.formLabel}>Command</label>
+                <FormInput fieldName="command" control={control} />
+              </div>
+            )}
+
+            <DialogFooter>
+              <Button type="submit">{editingId ? "Save Changes" : "Create"}</Button>
+            </DialogFooter>
+          </form>
+        </DialogContent>
+      </Dialog>
+    </div>
   );
 }

--- a/src/torrential-ui-vite/src/pages/integrations/integrations.module.css
+++ b/src/torrential-ui-vite/src/pages/integrations/integrations.module.css
@@ -1,0 +1,167 @@
+.integrationsRoot {
+  padding: 1rem;
+  flex: 1 1 auto;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  align-items: stretch;
+  width: 100%;
+  min-width: 0;
+  max-width: 62rem;
+  margin: 0 auto;
+  overflow: auto;
+}
+
+.pageTitle {
+  font-size: clamp(1.6rem, 4vw, 1.9rem);
+  font-weight: 600;
+  margin: 0;
+}
+
+.pageHeader {
+  width: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+}
+
+.addButton {
+  position: static;
+  min-width: 0;
+  min-height: var(--touch-target-min);
+  padding: 0.5rem 0.9rem;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.45rem;
+  border-radius: 0.6rem;
+  flex-shrink: 0;
+  white-space: nowrap;
+}
+
+.addButtonLabel {
+  display: inline;
+}
+
+.integrationsList {
+  display: flex;
+  flex-direction: column;
+  gap: 0;
+}
+
+.integrationCard {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+  padding: 0.75rem 0;
+  border-bottom: 1px solid hsl(var(--border));
+}
+
+.integrationCard:last-child {
+  border-bottom: none;
+}
+
+.integrationIcon {
+  width: 2.25rem;
+  height: 2.25rem;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 0.5rem;
+  background: hsl(var(--muted));
+  color: hsl(var(--muted-foreground));
+  flex-shrink: 0;
+  font-size: 1rem;
+}
+
+.integrationInfo {
+  flex: 1 1 auto;
+  min-width: 0;
+}
+
+.integrationName {
+  margin: 0;
+  font-weight: 500;
+  font-size: 0.95rem;
+  line-height: 1.35;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.integrationMeta {
+  margin: 0;
+  font-size: 0.8rem;
+  color: hsl(var(--muted-foreground));
+  line-height: 1.35;
+}
+
+.integrationActions {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  flex-shrink: 0;
+}
+
+.emptyState {
+  text-align: center;
+  padding: 3rem 1rem;
+  color: hsl(var(--muted-foreground));
+}
+
+.emptyState p {
+  margin: 0;
+  font-size: 0.95rem;
+}
+
+.dialogForm {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.formField {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+}
+
+.formLabel {
+  font-size: 0.85rem;
+  font-weight: 500;
+}
+
+.formSelect {
+  flex: 1;
+  height: 2.25rem;
+  width: 100%;
+  border-radius: 0.375rem;
+  border: 1px solid hsl(var(--input));
+  background-color: transparent;
+  padding: 0.25rem 0.75rem;
+  font-size: 0.875rem;
+  color: inherit;
+  outline: none;
+}
+
+.formSelect:focus-visible {
+  outline: none;
+  box-shadow: 0 0 0 1px hsl(var(--ring));
+}
+
+@media (max-width: 768px) {
+  .integrationsRoot {
+    padding: 0.75rem;
+    gap: 0.75rem;
+  }
+
+  .integrationCard {
+    gap: 0.75rem;
+  }
+
+  .addButton {
+    padding: 0.7rem 1rem;
+    min-height: var(--touch-target-min);
+  }
+}

--- a/src/torrential-ui-vite/src/services/api.ts
+++ b/src/torrential-ui-vite/src/services/api.ts
@@ -254,3 +254,52 @@ export async function browseDirectories(path?: string): Promise<DirectoryBrowseA
 
   return result.data;
 }
+
+// Integrations API
+
+export interface IntegrationApiModel {
+  id: string;
+  name: string;
+  type: string;
+  enabled: boolean;
+  triggerEvent: string;
+  configuration: string;
+}
+
+export async function fetchIntegrations(): Promise<IntegrationApiModel[]> {
+  const response = await fetch(`${import.meta.env.VITE_API_BASE_URL}/integrations`);
+  if (!response.ok) throw new Error("Error fetching integrations");
+  const result: ApiResponse<IntegrationApiModel[]> = await response.json();
+  return result.data ?? [];
+}
+
+export async function createIntegration(data: Omit<IntegrationApiModel, "id">): Promise<IntegrationApiModel> {
+  const response = await fetch(`${import.meta.env.VITE_API_BASE_URL}/integrations`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(data),
+  });
+  if (!response.ok) throw new Error("Error creating integration");
+  const result: ApiResponse<IntegrationApiModel> = await response.json();
+  if (!result.data) throw new Error("Create integration returned no data");
+  return result.data;
+}
+
+export async function updateIntegration(id: string, data: Omit<IntegrationApiModel, "id">): Promise<IntegrationApiModel> {
+  const response = await fetch(`${import.meta.env.VITE_API_BASE_URL}/integrations/${id}`, {
+    method: "PUT",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(data),
+  });
+  if (!response.ok) throw new Error("Error updating integration");
+  const result: ApiResponse<IntegrationApiModel> = await response.json();
+  if (!result.data) throw new Error("Update integration returned no data");
+  return result.data;
+}
+
+export async function deleteIntegration(id: string): Promise<boolean> {
+  const response = await fetch(`${import.meta.env.VITE_API_BASE_URL}/integrations/${id}`, {
+    method: "DELETE",
+  });
+  return response.ok;
+}


### PR DESCRIPTION
## Summary

- Create the Integration entity, IntegrationType enum, IntegrationService for CRUD, update DbContext, register in DI, and generate the EF Core migration.
- Add CRUD API endpoints for integrations, request/response models, and an IntegrationExecutor that listens on the event bus and logs mock execution of triggered integrations.
- Build the integrations page UI with a list of configured integrations, add/edit dialogs with type-specific forms, enable/disable toggles, and delete functionality.

## What was done

### Phase 1
- [x] Backend: Integration model, service, and DB migration
- [x] Backend: API endpoints and integration executor

### Phase 2
- [x] Frontend: Integrations page with CRUD UI

## Diff stat

```
 .../Integrations/IntegrationCreateRequest.cs       |  19 ++
 .../Responses/Integrations/IntegrationResponses.cs |  55 ++++
 src/Torrential.Web/Program.cs                      | 103 ++++++
 src/Torrential/Integrations/Integration.cs         |  18 ++
 src/Torrential/Integrations/IntegrationExecutor.cs |  23 ++
 src/Torrential/Integrations/IntegrationService.cs  |  66 ++++
 .../20260221140535_AddIntegrations.Designer.cs     | 133 ++++++++
 .../Migrations/20260221140535_AddIntegrations.cs   |  38 +++
 .../Migrations/TorrentialDbModelSnapshot.cs        |  30 ++
 src/Torrential/ServiceCollectionExtensions.cs      |   3 +
 src/Torrential/TorrentialDb.cs                     |  11 +
 .../src/pages/integrations/index.tsx               | 345 ++++++++++++++++++++-
 .../src/pages/integrations/integrations.module.css | 167 ++++++++++
 src/torrential-ui-vite/src/services/api.ts         |  49 +++
 14 files changed, 1059 insertions(+), 1 deletion(-)
```

---
*Generated by Jarvis*
